### PR TITLE
Move device-related logic from client to agent

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -48,6 +48,7 @@ dependencies {
     compile 'io.github.bonigarcia:webdrivermanager:1.5.0'
     compile 'org.seleniumhq.selenium:selenium-java:2.47.1'
     compile 'commons-net:commons-net:3.5'
+    compile 'org.reflections:reflections:0.9.10'
 
     compile 'org.glassfish.tyrus:tyrus-client:1.13.1'
     compile 'org.glassfish.tyrus:tyrus-container-grizzly-client:1.13.1'

--- a/build.gradle
+++ b/build.gradle
@@ -48,7 +48,7 @@ dependencies {
     compile 'io.github.bonigarcia:webdrivermanager:1.5.0'
     compile 'org.seleniumhq.selenium:selenium-java:2.47.1'
     compile 'commons-net:commons-net:3.5'
-    compile 'org.reflections:reflections:0.9.10'
+    compile 'org.reflections:reflections:0.9.9-RC1'
 
     compile 'org.glassfish.tyrus:tyrus-client:1.13.1'
     compile 'org.glassfish.tyrus:tyrus-container-grizzly-client:1.13.1'

--- a/src/main/java/com/musala/atmosphere/agent/devicewrapper/AbstractWrapDevice.java
+++ b/src/main/java/com/musala/atmosphere/agent/devicewrapper/AbstractWrapDevice.java
@@ -51,6 +51,7 @@ import com.musala.atmosphere.agent.devicewrapper.util.ShellCommandExecutor;
 import com.musala.atmosphere.agent.devicewrapper.util.ondevicecomponent.ServiceCommunicator;
 import com.musala.atmosphere.agent.devicewrapper.util.ondevicecomponent.UIAutomatorCommunicator;
 import com.musala.atmosphere.agent.entity.HardwareButtonEntity;
+import com.musala.atmosphere.agent.entity.ImeEntity;
 import com.musala.atmosphere.agent.exception.OnDeviceServiceTerminationException;
 import com.musala.atmosphere.agent.exception.UnresolvedEntityTypeException;
 import com.musala.atmosphere.agent.util.DeviceScreenResolutionParser;
@@ -172,6 +173,8 @@ public abstract class AbstractWrapDevice implements IWrapDevice {
     private FtpFileTransferService ftpFileTransferService;
 
     private HardwareButtonEntity hardwareButtonEntity;
+
+    private ImeEntity imeEntity;
 
     /**
      * Creates an abstract wrapper of the given {@link IDevice device}.
@@ -553,6 +556,26 @@ public abstract class AbstractWrapDevice implements IWrapDevice {
             case GET_AVAILABLE_DISK_SPACE:
                 returnValue = serviceCommunicator.getAvailableDiskSpace();
                 break;
+
+            // IME related
+            case IME_INPUT_TEXT:
+                returnValue = imeEntity.inputText((String) args[0], (Long) args[1]);
+                break;
+            case IME_SELECT_ALL_TEXT:
+                returnValue = imeEntity.selectAllText();
+                break;
+            case IME_CLEAR_TEXT:
+                returnValue = imeEntity.clearText();
+                break;
+            case IME_COPY_TEXT:
+                returnValue = imeEntity.copyText();
+                break;
+            case IME_CUT_TEXT:
+                returnValue = imeEntity.cutText();
+                break;
+            case IME_PASTE_TEXT:
+                returnValue = imeEntity.pasteText();
+                break;
         }
 
         return returnValue;
@@ -819,6 +842,11 @@ public abstract class AbstractWrapDevice implements IWrapDevice {
             HardwareButtonEntity hardwareButtonEntity = (HardwareButtonEntity) hardwareButtonEntityConstructor.newInstance(new Object[] {
                     shellCommandExecutor});
             this.hardwareButtonEntity = hardwareButtonEntity;
+
+            Constructor<?> imeEntityConstructor = ImeEntity.class.getDeclaredConstructor(ServiceCommunicator.class);
+            imeEntityConstructor.setAccessible(true);
+            ImeEntity imeEntity = (ImeEntity) imeEntityConstructor.newInstance(new Object[] {serviceCommunicator});
+            this.imeEntity = imeEntity;
         } catch (NoSuchMethodException | SecurityException | InstantiationException | IllegalAccessException
                 | IllegalArgumentException | InvocationTargetException e) {
             throw new UnresolvedEntityTypeException("Failed to find the correct set of entities implementations matching the given device information.",

--- a/src/main/java/com/musala/atmosphere/agent/devicewrapper/AbstractWrapDevice.java
+++ b/src/main/java/com/musala/atmosphere/agent/devicewrapper/AbstractWrapDevice.java
@@ -50,6 +50,7 @@ import com.musala.atmosphere.agent.devicewrapper.util.ImeManager;
 import com.musala.atmosphere.agent.devicewrapper.util.ShellCommandExecutor;
 import com.musala.atmosphere.agent.devicewrapper.util.ondevicecomponent.ServiceCommunicator;
 import com.musala.atmosphere.agent.devicewrapper.util.ondevicecomponent.UIAutomatorCommunicator;
+import com.musala.atmosphere.agent.entity.GestureEntity;
 import com.musala.atmosphere.agent.entity.HardwareButtonEntity;
 import com.musala.atmosphere.agent.entity.ImeEntity;
 import com.musala.atmosphere.agent.exception.OnDeviceServiceTerminationException;
@@ -70,6 +71,7 @@ import com.musala.atmosphere.commons.beans.MobileDataState;
 import com.musala.atmosphere.commons.beans.PhoneNumber;
 import com.musala.atmosphere.commons.beans.SwipeDirection;
 import com.musala.atmosphere.commons.exceptions.CommandFailedException;
+import com.musala.atmosphere.commons.geometry.Point;
 import com.musala.atmosphere.commons.gesture.Gesture;
 import com.musala.atmosphere.commons.ui.UiElementPropertiesContainer;
 import com.musala.atmosphere.commons.ui.selector.UiElementSelector;
@@ -175,6 +177,8 @@ public abstract class AbstractWrapDevice implements IWrapDevice {
     private HardwareButtonEntity hardwareButtonEntity;
 
     private ImeEntity imeEntity;
+
+    private GestureEntity gestureEntity;
 
     /**
      * Creates an abstract wrapper of the given {@link IDevice device}.
@@ -576,6 +580,29 @@ public abstract class AbstractWrapDevice implements IWrapDevice {
             case IME_PASTE_TEXT:
                 returnValue = imeEntity.pasteText();
                 break;
+
+            // Gesture related
+            case GESTURE_TAP:
+                returnValue = gestureEntity.tapScreenLocation((Point) args[0]);
+                break;
+            case GESTURE_LONG_PRESS:
+                returnValue = gestureEntity.longPress((Point) args[0], (Integer) args[1]);
+                break;
+            case GESTURE_DOUBLE_TAP:
+                returnValue = gestureEntity.doubleTap((Point) args[0]);
+                break;
+            case GESTURE_PINCH_IN:
+                returnValue = gestureEntity.pinchIn((Point) args[0], (Point) args[1]);
+                break;
+            case GESTURE_PINCH_OUT:
+                returnValue = gestureEntity.pinchOut((Point) args[0], (Point) args[1]);
+                break;
+            case GESTURE_SWIPE:
+                returnValue = gestureEntity.swipe((Point) args[0], (SwipeDirection) args[1]);
+                break;
+            case GESTURE_DRAG:
+                returnValue = gestureEntity.drag((Point) args[0], (Point) args[1]);
+                break;
         }
 
         return returnValue;
@@ -847,6 +874,19 @@ public abstract class AbstractWrapDevice implements IWrapDevice {
             imeEntityConstructor.setAccessible(true);
             ImeEntity imeEntity = (ImeEntity) imeEntityConstructor.newInstance(new Object[] {serviceCommunicator});
             this.imeEntity = imeEntity;
+
+            Constructor<?> gestureEntityConstructor = GestureEntity.class.getDeclaredConstructor(ShellCommandExecutor.class,
+                                                                                                  ServiceCommunicator.class,
+                                                                                                  DeviceInformation.class,
+                                                                                                  UIAutomatorCommunicator.class);
+            gestureEntityConstructor.setAccessible(true);
+            GestureEntity gestureEntity = (GestureEntity) gestureEntityConstructor.newInstance(new Object[] {
+                    shellCommandExecutor,
+                    serviceCommunicator,
+                    deviceInformation,
+                    automatorCommunicator
+            });
+            this.gestureEntity = gestureEntity;
         } catch (NoSuchMethodException | SecurityException | InstantiationException | IllegalAccessException
                 | IllegalArgumentException | InvocationTargetException e) {
             throw new UnresolvedEntityTypeException("Failed to find the correct set of entities implementations matching the given device information.",

--- a/src/main/java/com/musala/atmosphere/agent/devicewrapper/AbstractWrapDevice.java
+++ b/src/main/java/com/musala/atmosphere/agent/devicewrapper/AbstractWrapDevice.java
@@ -97,10 +97,6 @@ public abstract class AbstractWrapDevice implements IWrapDevice {
 
     private static final String XMLDUMP_LOCAL_FILE_NAME = "uidump-%s.xml";
 
-    private static final String SCREENSHOT_REMOTE_FILE_NAME = "/data/local/tmp/remote_screen.png";
-
-    private static final String SCREENSHOT_COMMAND = "screencap -p " + SCREENSHOT_REMOTE_FILE_NAME;
-
     private static final String LIST_RUNNING_PROCESSES_COMMAND = "ps";
 
     private static final String FORCE_STOP_PROCESS_COMMAND = "am force-stop ";
@@ -115,8 +111,6 @@ public abstract class AbstractWrapDevice implements IWrapDevice {
     private static final String GET_PID_FORMAT = "ps %s %s";
 
     private static final String GET_PID_PATTERN = "| grep -Eo [0-9]+ | grep -m 1 -Eo [0-9]+";
-
-    private static final String SCREENSHOT_LOCAL_FILE_NAME = "local_screen.png";
 
     private static final String FIRST_SCREEN_RECORD_NAME = "100.mp4";
 
@@ -975,38 +969,6 @@ public abstract class AbstractWrapDevice implements IWrapDevice {
                 | IllegalArgumentException | InvocationTargetException e) {
             throw new UnresolvedEntityTypeException("Failed to find the correct set of entities implementations matching the given device information.",
                                                     e);
-        }
-    }
-
-    /**
-     * Returns a JPEG compressed display screenshot.
-     *
-     * @return Image in an array of bytes that, when dumped to a file, shows the device display.
-     * @throws CommandFailedException
-     *         In case of an error in the execution
-     */
-    private String getScreenshot() throws CommandFailedException {
-        shellCommandExecutor.execute(SCREENSHOT_COMMAND);
-
-        FileInputStream fileReader = null;
-
-        try {
-            wrappedDevice.pullFile(SCREENSHOT_REMOTE_FILE_NAME, SCREENSHOT_LOCAL_FILE_NAME);
-
-            File localScreenshotFile = new File(SCREENSHOT_LOCAL_FILE_NAME);
-            fileReader = new FileInputStream(localScreenshotFile);
-
-            final long sizeOfScreenshotFile = localScreenshotFile.length();
-            byte[] screenshotData = new byte[(int) sizeOfScreenshotFile];
-            fileReader.read(screenshotData);
-            fileReader.close();
-
-            String screenshotBase64String = Base64.getEncoder().encodeToString(screenshotData);
-
-            return screenshotBase64String;
-        } catch (IOException | AdbCommandRejectedException | TimeoutException | SyncException e) {
-            LOGGER.error("Screenshot fetching failed.", e);
-            throw new CommandFailedException("Screenshot fetching failed.", e);
         }
     }
 

--- a/src/main/java/com/musala/atmosphere/agent/devicewrapper/AbstractWrapDevice.java
+++ b/src/main/java/com/musala/atmosphere/agent/devicewrapper/AbstractWrapDevice.java
@@ -53,6 +53,7 @@ import com.musala.atmosphere.agent.devicewrapper.util.ondevicecomponent.UIAutoma
 import com.musala.atmosphere.agent.entity.DeviceSettingsEntity;
 import com.musala.atmosphere.agent.entity.GestureEntity;
 import com.musala.atmosphere.agent.entity.HardwareButtonEntity;
+import com.musala.atmosphere.agent.entity.ImageEntity;
 import com.musala.atmosphere.agent.entity.ImeEntity;
 import com.musala.atmosphere.agent.exception.OnDeviceServiceTerminationException;
 import com.musala.atmosphere.agent.exception.UnresolvedEntityTypeException;
@@ -184,6 +185,8 @@ public abstract class AbstractWrapDevice implements IWrapDevice {
 
     private DeviceSettingsEntity settingsEntity;
 
+    private ImageEntity imageEntity;
+
     /**
      * Creates an abstract wrapper of the given {@link IDevice device}.
      *
@@ -275,7 +278,7 @@ public abstract class AbstractWrapDevice implements IWrapDevice {
                 returnValue = getDeviceInformation();
                 break;
             case GET_SCREENSHOT:
-                returnValue = getScreenshot();
+                returnValue = imageEntity.getScreenshot();
                 break;
             case GET_UI_XML_DUMP:
                 returnValue = getUiXml();
@@ -929,6 +932,15 @@ public abstract class AbstractWrapDevice implements IWrapDevice {
             DeviceSettingsEntity settingsEntity = (DeviceSettingsEntity) settingsEntitiyConstructor.newInstance(new Object[] {
                     shellCommandExecutor, deviceInformation});
             this.settingsEntity = settingsEntity;
+
+            Constructor<?> imageEntityConstructor = ImageEntity.class.getDeclaredConstructor(ShellCommandExecutor.class,
+                                                                                             IDevice.class);
+            imageEntityConstructor.setAccessible(true);
+            ImageEntity imageEntity = (ImageEntity) imageEntityConstructor.newInstance(new Object[] {
+                    shellCommandExecutor,
+                    wrappedDevice
+            });
+            this.imageEntity = imageEntity;
         } catch (NoSuchMethodException | SecurityException | InstantiationException | IllegalAccessException
                 | IllegalArgumentException | InvocationTargetException e) {
             throw new UnresolvedEntityTypeException("Failed to find the correct set of entities implementations matching the given device information.",

--- a/src/main/java/com/musala/atmosphere/agent/entity/DeviceSettingsEntity.java
+++ b/src/main/java/com/musala/atmosphere/agent/entity/DeviceSettingsEntity.java
@@ -1,0 +1,225 @@
+package com.musala.atmosphere.agent.entity;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.apache.log4j.Logger;
+
+import com.musala.atmosphere.agent.devicewrapper.util.ShellCommandExecutor;
+import com.musala.atmosphere.agent.util.settings.AndroidGlobalSettings;
+import com.musala.atmosphere.agent.util.settings.AndroidSystemSettings;
+import com.musala.atmosphere.agent.util.settings.DeviceSettingsManager;
+import com.musala.atmosphere.agent.util.settings.SettingsParsingException;
+import com.musala.atmosphere.commons.DeviceInformation;
+import com.musala.atmosphere.commons.ScreenOrientation;
+import com.musala.atmosphere.commons.exceptions.CommandFailedException;
+import com.musala.atmosphere.commons.util.IntentBuilder;
+import com.musala.atmosphere.commons.util.IntentBuilder.IntentAction;
+
+/**
+ * Entity responsible for retrieving and updating device settings.
+ *
+ * @author filareta.yordanova
+ *
+ */
+public class DeviceSettingsEntity {
+    private static final Logger LOGGER = Logger.getLogger(DeviceSettingsEntity.class);
+
+    private ShellCommandExecutor shellCommandExecutor;
+
+    private DeviceInformation deviceInformation;
+
+    private DeviceSettingsManager deviceSettingsManager;
+
+    /**
+     * Constructs a new {@link DeviceSettingsEntity} object by given {@link ShellCommandExecutor shell command executor} and
+     * {@link DeviceInformation}.
+     *
+     * @param shellCommandExecutor
+     *        - a shell command executor to execute shell commands with
+     * @param deviceInformation
+     *        - information container for the basic device properties
+     */
+    DeviceSettingsEntity(ShellCommandExecutor shellCommandExecutor, DeviceInformation deviceInformation) {
+        this.shellCommandExecutor = shellCommandExecutor;
+        this.deviceInformation = deviceInformation;
+        this.deviceSettingsManager = new DeviceSettingsManager(shellCommandExecutor);
+    }
+
+    /**
+     * Gets a {@link ScreenOrientation} instance that contains information about the orientation of the screen.
+     *
+     * @return {@link ScreenOrientation object} that shows how android elements are rotated on the screen
+     * @see ScreenOrientation
+     */
+    public ScreenOrientation getScreenOrientation() {
+        ScreenOrientation screenOrientation = null;
+        try {
+            int obtainedScreenOrientationValue = deviceSettingsManager.getInt(AndroidSystemSettings.USER_ROTATION);
+            screenOrientation = ScreenOrientation.getValueOfInt(obtainedScreenOrientationValue);
+        } catch (SettingsParsingException e) {
+            LOGGER.error("Failed to get screen orientation of the device.", e);
+        }
+
+        return screenOrientation;
+    }
+
+    /**
+     * Returns device auto rotation state.
+     *
+     * @return <code>true</code> if the auto rotation is on , <code>false</code> if it's not, <code>null</code> if the
+     *         method failed to get device auto rotation state
+     */
+    public Boolean isAutoRotationOn() {
+        Boolean isAutoRotationOn = null;
+        try {
+            int autoRotationValue = deviceSettingsManager.getInt(AndroidSystemSettings.ACCELEROMETER_ROTATION);
+            isAutoRotationOn = autoRotationValue == 1 ? true : false;
+
+        } catch (SettingsParsingException e) {
+            LOGGER.error("Getting autorotation status failed.", e);
+        }
+
+        return isAutoRotationOn;
+    }
+
+    /**
+     * Sets the airplane mode state for this device.<br>
+     * <i><b>Warning:</b> enabling airplane mode on an emulator disconnects it from the ATMOSPHERE Agent and this emulator
+     * could only be connected back after Agent restart. Setting airplane mode for emulators is prohibited.</i>
+     *
+     * @param airplaneMode
+     *        - <code>true</code> to enable airplane mode, <code>false</code> to disable airplane mode
+     * @return <code>true</code> if the airplane mode setting is successful, <code>false</code> if it fails
+     */
+    public boolean setAirplaneMode(boolean airplaneMode) {
+        boolean isEmulator = deviceInformation.isEmulator();
+        if (isEmulator) {
+            String message = "Enabling airplane mode on an emulator disconnects it from the ATMOSPHERE Agent and this emulator could only be connected back after Agent restart. Setting airplane mode for emulators is prohibited.";
+            LOGGER.warn(message);
+            return false;
+        }
+
+        int airplaneModeIntValue = airplaneMode ? 1 : 0;
+
+        IntentBuilder intentBuilder = new IntentBuilder(IntentAction.AIRPLANE_MODE_NOTIFICATION);
+        intentBuilder.putExtraBoolean("state", airplaneMode);
+        String intentCommand = intentBuilder.buildIntentCommand();
+
+        final String INTENT_COMMAND_RESPONSE = "Broadcast completed: result=0";
+
+        boolean success = deviceSettingsManager.putInt(AndroidGlobalSettings.AIRPLANE_MODE_ON, airplaneModeIntValue);
+        if (!success) {
+            String message = "Updating airplane mode status failed.";
+            LOGGER.error(message);
+            return false;
+        }
+
+        String intentCommandResponse;
+        try {
+            intentCommandResponse = shellCommandExecutor.execute(intentCommand);
+        } catch (CommandFailedException e) {
+            String message = "Executing shell command failed.";
+            LOGGER.error(message);
+            return false;
+        }
+        Pattern intentCommandResponsePattern = Pattern.compile(INTENT_COMMAND_RESPONSE);
+        Matcher intentCommandResponseMatcher = intentCommandResponsePattern.matcher(intentCommandResponse);
+        if (!intentCommandResponseMatcher.find()) {
+            String message = "Broadcasting notification intent failed.";
+            LOGGER.error(message);
+            return false;
+        }
+
+        return true;
+    }
+
+    /**
+     * Gets the airplane mode state of this device.<br>
+     *
+     * @return <code>true</code> if the airplane mode is on, <code>false</code> if it's off and <code>null</code> if
+     *         getting airplane mode fails
+     */
+    public Boolean getAirplaneMode() {
+        try {
+            int airplaneMode = deviceSettingsManager.getInt(AndroidGlobalSettings.AIRPLANE_MODE_ON);
+            return airplaneMode == 1;
+        } catch (SettingsParsingException e) {
+            LOGGER.error("Getting the Airplane mode of the device failed.", e);
+            return null;
+        }
+    }
+
+    /**
+     * Sets new screen orientation for this device.<br>
+     * Implicitly turns off screen auto rotation.
+     *
+     * @param screenOrientation
+     *        - new {@link ScreenOrientation ScreenOrientation} to be set
+     * @return <code>true</code> if the screen orientation setting is successful, <code>false</code> if it fails
+     */
+    public boolean setScreenOrientation(ScreenOrientation screenOrientation) {
+        if (!disableScreenAutoRotation()) {
+            String message = "Screen orientation was not set due to setting auto rotation failure.";
+            LOGGER.error(message);
+            return false;
+        }
+
+        boolean success = deviceSettingsManager.putInt(AndroidSystemSettings.USER_ROTATION,
+                                                       screenOrientation.getOrientationNumber());
+
+        return success;
+    }
+
+    /**
+     * Enables the screen auto rotation on this device.
+     *
+     * @return <code>true</code> if the auto rotation setting is successful, and <code>false</code> if it fails
+     */
+    public boolean enableScreenAutoRotation() {
+        return deviceSettingsManager.putInt(AndroidSystemSettings.ACCELEROMETER_ROTATION, 1);
+    }
+
+    /**
+     * Disables the screen auto rotation on this device.
+     *
+     * @return <code>true</code> if the auto rotation setting is successful, and <code>false</code> if it fails
+     */
+    public boolean disableScreenAutoRotation() {
+        return deviceSettingsManager.putInt(AndroidSystemSettings.ACCELEROMETER_ROTATION, 0);
+    }
+
+    /**
+     * Sets the timeout in the system settings, after which the screen is turned off.
+     * <p>
+     * Note: On emulators the screen is only dimmed.
+     * </p>
+     *
+     * @param screenOffTimeout
+     *        - timeout in milliseconds, after which the screen is turned off
+     * @return true if the given screen off timeout is successfully set
+     *
+     */
+    public boolean setScreenOffTimeout(long screenOffTimeout) {
+        return deviceSettingsManager.putLong(AndroidSystemSettings.SCREEN_OFF_TIMEOUT, screenOffTimeout);
+    }
+
+    /**
+     * Gets the timeout from the system settings, after which the screen is turned off.
+     *
+     * @return timeout in milliseconds, after which the screen is turned off
+     */
+    public long getScreenOffTimeout() {
+        return deviceSettingsManager.getLong(AndroidSystemSettings.SCREEN_OFF_TIMEOUT, 0);
+    }
+
+    /**
+     * Gets the {@link DeviceSettingsManager settings manager} of the current device, that allows getting and inserting
+     * device settings.
+     *
+     * @return {@link DeviceSettingsManager} instance for this device
+     */
+    public DeviceSettingsManager getDeviceSettingsManager() {
+        return deviceSettingsManager;
+    }
+}

--- a/src/main/java/com/musala/atmosphere/agent/entity/EntityTypeResolver.java
+++ b/src/main/java/com/musala/atmosphere/agent/entity/EntityTypeResolver.java
@@ -1,0 +1,93 @@
+package com.musala.atmosphere.agent.entity;
+
+import java.lang.annotation.Annotation;
+import java.util.Set;
+
+import org.reflections.Reflections;
+
+import com.musala.atmosphere.agent.entity.annotations.Restriction;
+import com.musala.atmosphere.commons.DeviceInformation;
+
+/**
+ * Class responsible for resolving the correct implementation of the entities, defined for all device specific
+ * operations, depending on the provided {@link DeviceInformation}.
+ *
+ * @author filareta.yordanova
+ *
+ */
+public class EntityTypeResolver {
+    private static final String ENTITIES_PACKAGE = "com.musala.atmosphere.agent.entity";
+
+    private DeviceInformation deviceInformation;
+
+    private Reflections reflections;
+
+    public EntityTypeResolver(DeviceInformation information) {
+        this.deviceInformation = information;
+        reflections = new Reflections(ENTITIES_PACKAGE);
+    }
+
+    /**
+     * Finds entity implementation for a device specific operation depending on the {@link DeviceInformation device
+     * information} and the hierarchy type given.
+     *
+     * @param baseEntityClass
+     *        - base class of the entity hierarchy for a device specific operation
+     * @return {@link Class} of the entity that matches the required {@link DeviceInformation device information} and is
+     *         from type baseEntityClass
+     */
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    public Class<?> getEntityClass(Class baseEntityClass) {
+        Set<Class<?>> subClasses = reflections.getSubTypesOf(baseEntityClass);
+        Class<?> defaultImplementation = null;
+
+        for (Class<?> subClass : subClasses) {
+            Annotation annotation = subClass.getAnnotation(Restriction.class);
+            if (annotation == null) {
+                defaultImplementation = subClass;
+            } else if (isApplicable((Restriction) annotation)) {
+                return subClass;
+            }
+        }
+
+        return defaultImplementation;
+
+    }
+
+    /**
+     * Checks if a certain implementation annotated with {@link @Restriction} is applicable for a device with the
+     * provided {@link DeviceInformation information}.
+     *
+     * @param restriction
+     *        - restrictions provided for a certain entity implementation
+     * @return <code>true</code> if the given restrictions are compatible with the {@link DeviceInformation information}
+     *         for the current device, <code>false</code> otherwise
+     */
+    // TODO: Check for default values in the annotation methods, if the parameter has default value and is not present
+    // in the annotation it is not considered when checking for applicability.
+    private boolean isApplicable(Restriction restriction) {
+        String manufacturer = restriction.manufacturer();
+
+        if (!manufacturer.equals(DeviceInformation.FALLBACK_MANUFACTURER_NAME)
+                && !manufacturer.equalsIgnoreCase(deviceInformation.getManufacturer())) {
+            return false;
+        }
+
+        boolean isApplicable = true;
+        int[] apiLevels = restriction.apiLevel();
+
+        if (apiLevels.length > 0) {
+            int deviceApiLevel = deviceInformation.getApiLevel();
+            isApplicable = false;
+
+            for (int applicableApiLevel : apiLevels) {
+                if (applicableApiLevel == deviceApiLevel) {
+                    isApplicable = true;
+                    break;
+                }
+            }
+        }
+
+        return isApplicable;
+    }
+}

--- a/src/main/java/com/musala/atmosphere/agent/entity/GestureEntity.java
+++ b/src/main/java/com/musala/atmosphere/agent/entity/GestureEntity.java
@@ -1,0 +1,217 @@
+package com.musala.atmosphere.agent.entity;
+
+import org.apache.log4j.Logger;
+
+import com.musala.atmosphere.agent.devicewrapper.util.ShellCommandExecutor;
+import com.musala.atmosphere.agent.devicewrapper.util.ondevicecomponent.ServiceCommunicator;
+import com.musala.atmosphere.agent.devicewrapper.util.ondevicecomponent.UIAutomatorCommunicator;
+import com.musala.atmosphere.agent.util.GestureCreator;
+import com.musala.atmosphere.commons.DeviceInformation;
+import com.musala.atmosphere.commons.beans.SwipeDirection;
+import com.musala.atmosphere.commons.exceptions.CommandFailedException;
+import com.musala.atmosphere.commons.geometry.Point;
+import com.musala.atmosphere.commons.gesture.Gesture;
+import com.musala.atmosphere.commons.util.Pair;
+
+/**
+ * Entity that contains the base gesture functionalities that can be executed on {@link UiElement}.
+ *
+ * @author yavor.stankov
+ *
+ */
+public class GestureEntity {
+    private static final Logger LOGGER = Logger.getLogger(GestureEntity.class.getCanonicalName());
+
+    private DeviceInformation deviceInformation;
+
+    private ShellCommandExecutor shellCommandExecutor;
+
+    private ServiceCommunicator serviceCommunicator;
+
+    private UIAutomatorCommunicator automatorCommunicator;
+
+    GestureEntity(ShellCommandExecutor shellCommandExecutor,
+                  ServiceCommunicator serviceCommunicator,
+                  DeviceInformation deviceInformation,
+                  UIAutomatorCommunicator automatorCommunicator) {
+        this.shellCommandExecutor = shellCommandExecutor;
+        this.serviceCommunicator = serviceCommunicator;
+        this.deviceInformation = deviceInformation;
+        this.automatorCommunicator = automatorCommunicator;
+    }
+
+    /**
+     * Executes a simple tap on the screen of this device at a specified location point.
+     *
+     * @param tapPoint
+     *        - {@link Point Point} on the screen to tap on
+     *
+     * @return <code>true</code> if tapping screen is successful, <code>false</code> if it fails
+     */
+    public boolean tapScreenLocation(Point tapPoint) {
+        boolean isTapSuccessful = true;
+
+        int tapPointX = tapPoint.getX();
+        int tapPointY = tapPoint.getY();
+        String query = "input tap " + tapPointX + " " + tapPointY;
+
+        showTapLocation(tapPoint);
+
+        try {
+            shellCommandExecutor.execute(query);
+        } catch (CommandFailedException e) {
+            isTapSuccessful = false;
+        }
+
+        return isTapSuccessful;
+    }
+
+    /**
+     * Executes long press on point on the screen with given coordinates and timeout for the gesture in ms.
+     *
+     * @param pressPoint
+     *        - {@link Point point} on the screen where the long press should be executed
+     * @param timeout
+     *        - the time in ms, showing how long should the holding part of the gesture continue
+     * @return - true, if operation is successful, and false otherwise
+     */
+    public boolean longPress(Point pressPoint, int timeout) {
+        Gesture longPress = GestureCreator.createLongPress(pressPoint.getX(), pressPoint.getY(), timeout);
+
+        return playGesture(longPress);
+    }
+
+    /**
+     * Simulates a double tap on the specified point.
+     *
+     * @param point
+     *        - the point to be tapped
+     * @return <code>true</code> if the double tap is successful, <code>false</code> if it fails
+     */
+    public boolean doubleTap(Point point) {
+        Gesture doubleTap = GestureCreator.createDoubleTap(point.getX(), point.getY());
+
+        return playGesture(doubleTap);
+    }
+
+    /**
+     * Simulates a pinch in having the initial coordinates of the fingers performing it.
+     *
+     * @param firstFingerInitial
+     *        - the initial position of the first finger
+     * @param secondFingerInitial
+     *        - the initial position of the second finger
+     * @return <code>true</code> if the pinch in is successful, <code>false</code> if it fails
+     */
+    public boolean pinchIn(Point firstFingerInitial, Point secondFingerInitial) {
+        validatePointOnScreen(firstFingerInitial);
+        validatePointOnScreen(secondFingerInitial);
+
+        Gesture pinchIn = GestureCreator.createPinchIn(firstFingerInitial, secondFingerInitial);
+
+        return playGesture(pinchIn);
+    }
+
+    /**
+     * Simulates a pinch out having the positions of the fingers performing it in the end of the gesture.
+     *
+     * @param firstFingerEnd
+     *        - the position of the first finger in the end of the gesture
+     * @param secondFingerEnd
+     *        - the position of the second finger in the end of the gesture
+     * @return <code>true</code> if the pinch out is successful, <code>false</code> if it fails
+     */
+    public boolean pinchOut(Point firstFingerEnd, Point secondFingerEnd) {
+        validatePointOnScreen(firstFingerEnd);
+        validatePointOnScreen(secondFingerEnd);
+
+        Gesture pinchOut = GestureCreator.createPinchOut(firstFingerEnd, secondFingerEnd);
+
+        return playGesture(pinchOut);
+    }
+
+    /**
+     * Simulates a swipe from a point to another unknown point.
+     *
+     * @param point
+     *        - the starting point
+     * @param swipeDirection
+     *        - a direction for the swipe action
+     * @return <code>true</code> if the swipe is successful, <code>false</code> if it fails
+     */
+    public boolean swipe(Point point, SwipeDirection swipeDirection) {
+        validatePointOnScreen(point);
+
+        Pair<Integer, Integer> resolution = deviceInformation.getResolution();
+        Gesture swipe = GestureCreator.createSwipe(point, swipeDirection, resolution);
+
+        return playGesture(swipe);
+    }
+
+    /**
+     * Drags and drops from point (Point startPoint) to point (Point endPoint).
+     *
+     * @param startPoint
+     *        - start point of the drag and drop gesture
+     * @param endPoint
+     *        - end point of the drag and drop gesture
+     * @return <code>true</code>, if operation is successful, <code>false</code>otherwise
+     */
+    public boolean drag(Point startPoint, Point endPoint) {
+        validatePointOnScreen(endPoint);
+        Gesture drag = GestureCreator.createDrag(startPoint, endPoint);
+
+        return playGesture(drag);
+    }
+
+    private boolean playGesture(Gesture gesture) {
+        boolean isPlayGestureSuccessful = true;
+
+        try {
+            automatorCommunicator.playGesture(gesture);
+        } catch (CommandFailedException e) {
+            isPlayGestureSuccessful = false;
+        }
+
+        return isPlayGestureSuccessful;
+    }
+
+    /**
+     * Shows the tap location on the current device screen.
+     *
+     * @param point
+     *        - the point where the tap will be placed
+     */
+    private void showTapLocation(Point point) {
+        try {
+            serviceCommunicator.showTapLocation(new Object[] {point});
+        } catch (CommandFailedException e) {
+            LOGGER.error(e.getMessage());
+        }
+    }
+
+    /**
+     * Checks whether the given point is inside the bounds of the screen, and throws an {@link IllegalArgumentException}
+     * otherwise.
+     *
+     * @param point
+     *        - the point to be checked
+     */
+    private void validatePointOnScreen(Point point) {
+        Pair<Integer, Integer> resolution = deviceInformation.getResolution();
+
+        boolean hasPositiveCoordinates = point.getX() >= 0 && point.getY() >= 0;
+        boolean isOnScreen = point.getX() <= resolution.getKey() && point.getY() <= resolution.getValue();
+
+        if (!hasPositiveCoordinates || !isOnScreen) {
+            String exeptionMessageFormat = "The passed point with coordinates (%d, %d) is outside the bounds of the screen. Screen dimentions (%d, %d)";
+            String message = String.format(exeptionMessageFormat,
+                                           point.getX(),
+                                           point.getY(),
+                                           resolution.getKey(),
+                                           resolution.getValue());
+            LOGGER.error(message);
+            throw new IllegalArgumentException(message);
+        }
+    }
+}

--- a/src/main/java/com/musala/atmosphere/agent/entity/GpsLocationCheckBoxEntity.java
+++ b/src/main/java/com/musala/atmosphere/agent/entity/GpsLocationCheckBoxEntity.java
@@ -1,0 +1,49 @@
+package com.musala.atmosphere.agent.entity;
+
+import java.util.List;
+
+import com.musala.atmosphere.agent.devicewrapper.util.ondevicecomponent.ServiceCommunicator;
+import com.musala.atmosphere.agent.devicewrapper.util.ondevicecomponent.UIAutomatorCommunicator;
+import com.musala.atmosphere.agent.entity.annotations.Restriction;
+import com.musala.atmosphere.commons.exceptions.CommandFailedException;
+import com.musala.atmosphere.commons.exceptions.UiElementFetchingException;
+import com.musala.atmosphere.commons.ui.UiElementPropertiesContainer;
+import com.musala.atmosphere.commons.ui.selector.CssAttribute;
+import com.musala.atmosphere.commons.ui.selector.UiElementSelector;
+import com.musala.atmosphere.commons.ui.tree.AccessibilityElement;
+
+/**
+ * {@link GpsLocationEntity} responsible for setting the GPS location state on all Samsung devices.
+ *
+ * @author yavor.stankov
+ *
+ */
+@Restriction(apiLevel = {17, 18})
+public class GpsLocationCheckBoxEntity extends GpsLocationEntity {
+    private static final String ANDROID_WIDGET_CHECK_BOX_CLASS_NAME = "android.widget.CheckBox";
+
+    GpsLocationCheckBoxEntity(ServiceCommunicator serviceCommunicator,
+                      UIAutomatorCommunicator automatorCommunicator,
+                      HardwareButtonEntity hardwareButtonEntity,
+                      GestureEntity gestureEntity) {
+        super(serviceCommunicator, automatorCommunicator, hardwareButtonEntity, gestureEntity);
+    }
+
+    @Override
+    protected UiElementPropertiesContainer getChangeStateWidget() throws UiElementFetchingException, CommandFailedException {
+        UiElementSelector checkBoxWidgetSelector = new UiElementSelector();
+        checkBoxWidgetSelector.addSelectionAttribute(CssAttribute.CLASS_NAME, ANDROID_WIDGET_CHECK_BOX_CLASS_NAME);
+
+        automatorCommunicator.waitForExists(checkBoxWidgetSelector, CHANGE_STATE_WIDGET_TIMEOUT);
+
+        List<AccessibilityElement> widgetList = automatorCommunicator.getUiElements(checkBoxWidgetSelector, true);
+
+        if (!widgetList.isEmpty()) {
+            // There are more than one check box on the screen, but only the first one is for setting the GPS location
+            // state.
+            return widgetList.get(0);
+        }
+
+        return null;
+    }
+}

--- a/src/main/java/com/musala/atmosphere/agent/entity/GpsLocationEntity.java
+++ b/src/main/java/com/musala/atmosphere/agent/entity/GpsLocationEntity.java
@@ -1,0 +1,165 @@
+package com.musala.atmosphere.agent.entity;
+
+import java.util.List;
+
+import org.apache.log4j.Logger;
+
+import com.musala.atmosphere.agent.devicewrapper.util.ondevicecomponent.ServiceCommunicator;
+import com.musala.atmosphere.agent.devicewrapper.util.ondevicecomponent.UIAutomatorCommunicator;
+import com.musala.atmosphere.commons.exceptions.CommandFailedException;
+import com.musala.atmosphere.commons.exceptions.UiElementFetchingException;
+import com.musala.atmosphere.commons.geometry.Bounds;
+import com.musala.atmosphere.commons.geometry.Point;
+import com.musala.atmosphere.commons.ui.UiElementPropertiesContainer;
+import com.musala.atmosphere.commons.ui.selector.CssAttribute;
+import com.musala.atmosphere.commons.ui.selector.UiElementSelector;
+import com.musala.atmosphere.commons.ui.tree.AccessibilityElement;
+
+/**
+ * Base entity responsible for handling GPS location state changing.
+ *
+ * @author yavor.stankov
+ *
+ */
+public abstract class GpsLocationEntity {
+    private static final Logger LOGGER = Logger.getLogger(GpsLocationEntity.class.getCanonicalName());
+
+    private static final String AGREE_BUTTON_RESOURCE_ID = "android:id/button1";
+
+    private static final int AGREE_BUTTON_TIMEOUT = 3000;
+
+    protected static final int CHANGE_STATE_WIDGET_TIMEOUT = 5000;
+
+    private static final int UI_ELEMENT_OPERATION_WAIT_TIME = 500;
+
+    protected ServiceCommunicator serviceCommunicator;
+
+    protected UIAutomatorCommunicator automatorCommunicator;
+
+    protected HardwareButtonEntity hardwareButtonEntity;
+
+    protected GestureEntity gestureEntity;
+
+    GpsLocationEntity(ServiceCommunicator serviceCommunicator,
+                      UIAutomatorCommunicator automatorCommunicator,
+                      HardwareButtonEntity hardwareButtonEntity,
+                      GestureEntity gestureEntity) {
+        this.serviceCommunicator = serviceCommunicator;
+        this.automatorCommunicator = automatorCommunicator;
+        this.hardwareButtonEntity = hardwareButtonEntity;
+        this.gestureEntity = gestureEntity;
+    }
+
+    /**
+     * Gets the right widget that is responsible for setting the GPS location state.
+     *
+     * @return the widget that should be used for setting the GPS location state.
+     * @throws UiElementFetchingException
+     *         if the required widget is not present on the screen
+     * @throws MultipleElementsFoundException
+     *         if there are more than one widgets present on the screen
+     */
+    protected abstract UiElementPropertiesContainer getChangeStateWidget()
+        throws UiElementFetchingException, CommandFailedException;
+
+    /**
+     * Enables the GPS location on this device.
+     *
+     * @return <code>true</code> if the GPS location enabling is successful, <code>false</code> if it fails
+     * @throws CommandFailedException
+     */
+    public boolean enableGpsLocation() throws CommandFailedException {
+        return setGpsLocationState(true);
+    }
+
+    /**
+     * Disables the GPS location on this device.
+     *
+     * @return <code>true</code> if the GPS location disabling is successful, <code>false</code> if it fails
+     * @throws CommandFailedException
+     */
+    public boolean disableGpsLocation() throws CommandFailedException {
+        return setGpsLocationState(false);
+    }
+
+    /**
+     * Check if the GPS location is enabled on this device.
+     *
+     * @return <code>true</code> if the GPS location is enabled, <code>false</code> if it's disabled
+     * @throws CommandFailedException
+     */
+    public boolean isGpsLocationEnabled() throws CommandFailedException {
+        return serviceCommunicator.isGpsLocationEnabled();
+    }
+
+    private boolean setGpsLocationState(boolean state) throws CommandFailedException {
+        if (isGpsLocationEnabled() == state) {
+            return true;
+        }
+
+        openLocationSettings();
+
+        try {
+            UiElementPropertiesContainer changeStateWidget = getChangeStateWidget();
+            if (tap(changeStateWidget)) {
+                pressAgreeButton();
+            }
+        } catch (UiElementFetchingException e) {
+            LOGGER.error("Failed to get the wanted widget, or there are more than one widgets on the screen that are matching the given selector.",
+                         e);
+            return false;
+        }
+
+        // TODO: If needed, move the HardwareButton enumeration from com.musala.atmosphere.client.device to atmosphere-commons,
+        // so the enumeration could be used here instead of an integer.
+        hardwareButtonEntity.pressButton(4); // Back button
+
+        return true;
+    }
+
+    public void openLocationSettings() throws CommandFailedException {
+        serviceCommunicator.openLocationSettings();
+    }
+
+    private void pressAgreeButton() throws UiElementFetchingException, CommandFailedException {
+        UiElementSelector agreeButtonSelector = new UiElementSelector();
+        agreeButtonSelector.addSelectionAttribute(CssAttribute.RESOURCE_ID, AGREE_BUTTON_RESOURCE_ID);
+
+        if (automatorCommunicator.waitForExists(agreeButtonSelector, AGREE_BUTTON_TIMEOUT)) {
+            List<AccessibilityElement> elementsList = automatorCommunicator.getUiElements(agreeButtonSelector, true);
+
+            AccessibilityElement agreeButton = elementsList.get(0);
+            tap(agreeButton);
+        }
+    }
+
+    private boolean tap(UiElementPropertiesContainer element) {
+        Bounds elementBounds = element.getBounds();
+        Point centerPoint = elementBounds.getCenter();
+        Point point = elementBounds.getRelativePoint(centerPoint);
+        Point tapPoint = elementBounds.getUpperLeftCorner();
+        tapPoint.addVector(point);
+
+        boolean tapSuccessful = false;
+        if (elementBounds.contains(tapPoint)) {
+            tapSuccessful = gestureEntity.tapScreenLocation(tapPoint);
+            finalizeUiElementOperation();
+        }  else {
+            String message = String.format("Point %s not in element bounds.", point.toString());
+            LOGGER.error(message);
+            throw new IllegalArgumentException(message);
+        }
+
+        return tapSuccessful;
+    }
+
+    private void finalizeUiElementOperation() {
+        // Should be invoked exactly once in the end of all element-operating
+        // methods, whether its directly or indirectly invoked.
+        try {
+            Thread.sleep(UI_ELEMENT_OPERATION_WAIT_TIME);
+        } catch (InterruptedException e) {
+            LOGGER.info(e);
+        }
+    }
+}

--- a/src/main/java/com/musala/atmosphere/agent/entity/GpsLocationSwitchViewEntity.java
+++ b/src/main/java/com/musala/atmosphere/agent/entity/GpsLocationSwitchViewEntity.java
@@ -1,0 +1,49 @@
+package com.musala.atmosphere.agent.entity;
+
+import java.util.List;
+
+import com.musala.atmosphere.agent.devicewrapper.util.ondevicecomponent.ServiceCommunicator;
+import com.musala.atmosphere.agent.devicewrapper.util.ondevicecomponent.UIAutomatorCommunicator;
+import com.musala.atmosphere.agent.entity.annotations.Default;
+import com.musala.atmosphere.commons.exceptions.CommandFailedException;
+import com.musala.atmosphere.commons.exceptions.UiElementFetchingException;
+import com.musala.atmosphere.commons.ui.UiElementPropertiesContainer;
+import com.musala.atmosphere.commons.ui.selector.CssAttribute;
+import com.musala.atmosphere.commons.ui.selector.UiElementSelector;
+import com.musala.atmosphere.commons.ui.tree.AccessibilityElement;
+
+/**
+ * {@link GpsLocationEntity} responsible for all devices that are using switch widgets for setting the GPS location
+ * state.
+ *
+ * @author yavor.stankov
+ *
+ */
+@Default
+public class GpsLocationSwitchViewEntity extends GpsLocationEntity {
+    private static final String ANDROID_WIDGET_SWITCH_RESOURCE_ID = "com.android.settings:id/switch_widget";
+
+    GpsLocationSwitchViewEntity(ServiceCommunicator serviceCommunicator,
+                                UIAutomatorCommunicator automatorCommunicator,
+                                HardwareButtonEntity hardwareButtonEntity,
+                                GestureEntity gestureEntity) {
+        super(serviceCommunicator, automatorCommunicator, hardwareButtonEntity, gestureEntity);
+    }
+
+    @Override
+    protected UiElementPropertiesContainer getChangeStateWidget() throws UiElementFetchingException, CommandFailedException {
+
+        UiElementSelector switchWidgetSelector = new UiElementSelector();
+        switchWidgetSelector.addSelectionAttribute(CssAttribute.RESOURCE_ID, ANDROID_WIDGET_SWITCH_RESOURCE_ID);
+
+        automatorCommunicator.waitForExists(switchWidgetSelector, CHANGE_STATE_WIDGET_TIMEOUT);
+
+        List<AccessibilityElement> widgetList = automatorCommunicator.getUiElements(switchWidgetSelector, true);
+
+        if (!widgetList.isEmpty()) {
+            return widgetList.get(0);
+        }
+
+        return null;
+    }
+}

--- a/src/main/java/com/musala/atmosphere/agent/entity/HardwareButtonEntity.java
+++ b/src/main/java/com/musala/atmosphere/agent/entity/HardwareButtonEntity.java
@@ -1,0 +1,37 @@
+package com.musala.atmosphere.agent.entity;
+
+import com.musala.atmosphere.agent.devicewrapper.util.ShellCommandExecutor;
+import com.musala.atmosphere.commons.exceptions.CommandFailedException;
+
+/**
+ * Entity responsible for operations related with hardware buttons.
+ *
+ * @author filareta.yordanova
+ *
+ */
+public class HardwareButtonEntity {
+    private ShellCommandExecutor shellCommandExecutor;
+
+    HardwareButtonEntity(ShellCommandExecutor shellCommandExecutor) {
+        this.shellCommandExecutor = shellCommandExecutor;
+    }
+
+    /**
+     * Presses hardware button on this device.
+     *
+     * @param keyCode
+     *        - button key code as specified by the Android KeyEvent KEYCODE_ constants
+     * @return <code>true</code> if the hardware button press is successful, <code>false</code> if it fails
+     */
+    public Boolean pressButton(int keyCode) {
+        String query = "input keyevent " + Integer.toString(keyCode);
+        boolean response = true;
+        try {
+            shellCommandExecutor.execute(query);
+        } catch (CommandFailedException e) {
+            response = false;
+        }
+
+        return response;
+    }
+}

--- a/src/main/java/com/musala/atmosphere/agent/entity/ImageEntity.java
+++ b/src/main/java/com/musala/atmosphere/agent/entity/ImageEntity.java
@@ -3,6 +3,7 @@ package com.musala.atmosphere.agent.entity;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
+import java.util.Base64;
 
 import org.apache.log4j.Logger;
 
@@ -50,10 +51,11 @@ public class ImageEntity {
     /**
      * Returns a JPEG compressed display screenshot.
      *
-     * @return Image in an array of bytes that, when dumped to a file, shows the device display.
+     * @return Image as base64 encoded {@link String}
      * @throws CommandFailedException
+     *         In case of an error in the execution
      */
-    public byte[] getScreenshot() throws CommandFailedException {
+    public String getScreenshot() throws CommandFailedException {
         shellCommandExecutor.execute(SCREENSHOT_COMMAND);
 
         FileInputStream fileReader = null;
@@ -69,7 +71,9 @@ public class ImageEntity {
             fileReader.read(screenshotData);
             fileReader.close();
 
-            return screenshotData;
+            String screenshotBase64String = Base64.getEncoder().encodeToString(screenshotData);
+
+            return screenshotBase64String;
         } catch (IOException | AdbCommandRejectedException | TimeoutException | SyncException e) {
             LOGGER.error("Screenshot fetching failed.", e);
             throw new CommandFailedException("Screenshot fetching failed.", e);

--- a/src/main/java/com/musala/atmosphere/agent/entity/ImageEntity.java
+++ b/src/main/java/com/musala/atmosphere/agent/entity/ImageEntity.java
@@ -1,0 +1,78 @@
+package com.musala.atmosphere.agent.entity;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+
+import org.apache.log4j.Logger;
+
+import com.android.ddmlib.AdbCommandRejectedException;
+import com.android.ddmlib.IDevice;
+import com.android.ddmlib.SyncException;
+import com.android.ddmlib.TimeoutException;
+import com.musala.atmosphere.agent.devicewrapper.util.ShellCommandExecutor;
+import com.musala.atmosphere.commons.exceptions.CommandFailedException;
+
+/**
+ * Entity responsible for operations related with images.
+ *
+ * @author yavor.stankov
+ *
+ */
+public class ImageEntity {
+    private static final Logger LOGGER = Logger.getLogger(ImageEntity.class.getCanonicalName());
+
+    private static final String SCREENSHOT_REMOTE_FILE_NAME = "/data/local/tmp/remote_screen.png";
+
+    private static final String SCREENSHOT_LOCAL_FILE_NAME = "local_screen.png";
+
+    private static final String SCREENSHOT_COMMAND = "screencap -p " + SCREENSHOT_REMOTE_FILE_NAME;
+
+    private ShellCommandExecutor shellCommandExecutor;
+
+    private IDevice wrappedDevice;
+
+    /**
+     * Constructs a new {@link ImageEntity} object by a given {@link ShellCommandExecutor shell command executor}
+     * and a {@link IDevice wrapped ddmlib device}.
+     *
+     * @param shellCommandExecutor
+     *        - a shell command executor to execute shell commands with
+     *
+     * @param wrappedDevice
+     *        - a wrapped ddmlib device
+     */
+    ImageEntity(ShellCommandExecutor shellCommandExecutor, IDevice wrappedDevice) {
+        this.shellCommandExecutor = shellCommandExecutor;
+        this.wrappedDevice = wrappedDevice;
+    }
+
+    /**
+     * Returns a JPEG compressed display screenshot.
+     *
+     * @return Image in an array of bytes that, when dumped to a file, shows the device display.
+     * @throws CommandFailedException
+     */
+    public byte[] getScreenshot() throws CommandFailedException {
+        shellCommandExecutor.execute(SCREENSHOT_COMMAND);
+
+        FileInputStream fileReader = null;
+
+        try {
+            wrappedDevice.pullFile(SCREENSHOT_REMOTE_FILE_NAME, SCREENSHOT_LOCAL_FILE_NAME);
+
+            File localScreenshotFile = new File(SCREENSHOT_LOCAL_FILE_NAME);
+            fileReader = new FileInputStream(localScreenshotFile);
+
+            final long sizeOfScreenshotFile = localScreenshotFile.length();
+            byte[] screenshotData = new byte[(int) sizeOfScreenshotFile];
+            fileReader.read(screenshotData);
+            fileReader.close();
+
+            return screenshotData;
+        } catch (IOException | AdbCommandRejectedException | TimeoutException | SyncException e) {
+            LOGGER.error("Screenshot fetching failed.", e);
+            throw new CommandFailedException("Screenshot fetching failed.", e);
+        }
+    }
+}

--- a/src/main/java/com/musala/atmosphere/agent/entity/ImeEntity.java
+++ b/src/main/java/com/musala/atmosphere/agent/entity/ImeEntity.java
@@ -1,0 +1,130 @@
+package com.musala.atmosphere.agent.entity;
+
+import org.apache.log4j.Logger;
+
+import com.musala.atmosphere.agent.devicewrapper.util.ondevicecomponent.ServiceCommunicator;
+import com.musala.atmosphere.commons.exceptions.CommandFailedException;
+import com.musala.atmosphere.commons.geometry.Point;
+import com.musala.atmosphere.commons.ime.KeyboardAction;
+import com.musala.atmosphere.commons.util.AtmosphereIntent;
+
+import android.bluetooth.BluetoothClass.Device;
+
+/**
+ * Entity responsible for operations related with the input method engine.
+ *
+ * @author yavor.stankov
+ *
+ */
+public class ImeEntity {
+    private static final Logger LOGGER = Logger.getLogger(ImeEntity.class.getCanonicalName());
+
+    private ServiceCommunicator communicator;
+
+    ImeEntity(ServiceCommunicator communicator) {
+        this.communicator = communicator;
+    }
+
+    /**
+     * Simulates text typing in the element on focus for this device. It is user's responsibility to focus an editable
+     * android widget using {@link Device#tapScreenLocation(Point) Device.tapScreenLocation()}, {@link UiElement#tap()
+     * UiElement.tap()} or {@link UiElement#focus() UiElement.focus()} methods.
+     *
+     * @param text
+     *        - text to be input
+     * @param interval
+     *        - time interval in milliseconds between typing each symbol
+     * @return <code>true</code> if the text input is successful, <code>false</code> if it fails
+     */
+    public boolean inputText(String text, long interval) {
+        if (text.isEmpty()) {
+            String message = "Text input requested, but an empty String is given.";
+            LOGGER.warn(message);
+            return true;
+        }
+
+        AtmosphereIntent intent = new AtmosphereIntent(KeyboardAction.INPUT_TEXT.intentAction);
+        intent.putExtra(KeyboardAction.INTENT_EXTRA_TEXT, text);
+        intent.putExtra(KeyboardAction.INTENT_EXTRA_INPUT_SPEED, interval);
+
+        boolean result = sendBroadcast(intent);
+
+        waitForTaskCompletion(text.length() * interval);
+
+        return result;
+    }
+
+    /**
+     * Clears the content of the focused text field.
+     *
+     * @return <code>true</code> if clear text is successful, <code>false</code> if it fails
+     */
+    public boolean clearText() {
+        AtmosphereIntent intent = new AtmosphereIntent(KeyboardAction.DELETE_ALL.intentAction);
+
+        return sendBroadcast(intent);
+    }
+
+    /**
+     * Selects the content of the focused text field.
+     *
+     * @return <code>true</code> if the text selecting is successful, <code>false</code> if it fails
+     */
+    public boolean selectAllText() {
+        AtmosphereIntent intent = new AtmosphereIntent(KeyboardAction.SELECT_ALL.intentAction);
+
+        return sendBroadcast(intent);
+    }
+
+    /**
+     * Copies the selected content of the focused text field.
+     *
+     * @return <code>true</code> if copy operation is successful, <code>false</code> if it fails
+     */
+    public boolean copyText() {
+        AtmosphereIntent intent = new AtmosphereIntent(KeyboardAction.COPY_TEXT.intentAction);
+
+        return sendBroadcast(intent);
+    }
+
+    /**
+     * Paste a copied text in the current focused text field.
+     *
+     * @return <code>true</code> if the operation is successful, <code>false</code> if it fails
+     */
+    public boolean pasteText() {
+        AtmosphereIntent intent = new AtmosphereIntent(KeyboardAction.PASTE_TEXT.intentAction);
+
+        return sendBroadcast(intent);
+    }
+
+    /**
+     * Cuts the selected text from the current focused text field.
+     *
+     * @return <code>true</code> if the operation is successful, <code>false</code> if it fails
+     */
+    public boolean cutText() {
+        AtmosphereIntent intent = new AtmosphereIntent(KeyboardAction.CUT_TEXT.intentAction);
+
+        return sendBroadcast(intent);
+    }
+
+    private boolean sendBroadcast(AtmosphereIntent intent) {
+
+        try {
+            communicator.sendBroadcast(new Object[] {intent});
+        } catch (CommandFailedException e) {
+            return false;
+        }
+
+        return true;
+    }
+
+    private void waitForTaskCompletion(long timeoutInMs) {
+        try {
+            Thread.sleep(timeoutInMs);
+        } catch (InterruptedException e) {
+            // Nothing to do here
+        }
+    }
+}

--- a/src/main/java/com/musala/atmosphere/agent/entity/annotations/Default.java
+++ b/src/main/java/com/musala/atmosphere/agent/entity/annotations/Default.java
@@ -1,0 +1,17 @@
+package com.musala.atmosphere.agent.entity.annotations;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Annotation that will be used to denote default implementations for a certain functionality defined as an entity.
+ *
+ * @author filareta.yordanova
+ *
+ */
+@Target({ElementType.TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface Default {
+}

--- a/src/main/java/com/musala/atmosphere/agent/entity/annotations/Restriction.java
+++ b/src/main/java/com/musala/atmosphere/agent/entity/annotations/Restriction.java
@@ -1,0 +1,34 @@
+package com.musala.atmosphere.agent.entity.annotations;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import com.musala.atmosphere.commons.DeviceInformation;
+
+/**
+ * Annotation that will be used for denoting restrictions on a group of devices that supports a certain implementation
+ * for a functionality defined as an entity. All criteria used for group separation might be added to this interface.
+ *
+ * @author filareta.yordanova
+ *
+ */
+@Target({ElementType.TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface Restriction {
+    /**
+     *
+     * Manufacturer of the device that must be built with the annotated entity.
+     *
+     * @return String
+     */
+    String manufacturer() default DeviceInformation.FALLBACK_MANUFACTURER_NAME;
+
+    /**
+     * Api level of the device that must be built with the annotated entity.
+     *
+     * @return int[]
+     */
+    int[] apiLevel() default {};
+}

--- a/src/main/java/com/musala/atmosphere/agent/exception/UnresolvedEntityTypeException.java
+++ b/src/main/java/com/musala/atmosphere/agent/exception/UnresolvedEntityTypeException.java
@@ -1,0 +1,44 @@
+package com.musala.atmosphere.agent.exception;
+
+import com.musala.atmosphere.commons.exceptions.AtmosphereRuntimeException;
+
+/**
+ * Thrown when unable to resolve the correct entity implementation matching the given restrictions or could not find a
+ * default one.
+ *
+ * @author filareta.yordanova
+ *
+ */
+public class UnresolvedEntityTypeException extends AtmosphereRuntimeException {
+    private static final long serialVersionUID = 4349519112412357251L;
+
+    /**
+     * Creates new {@link UnresolvedEntityTypeException UnresolvedEntityTypeException}.
+     */
+    public UnresolvedEntityTypeException() {
+        super();
+    }
+
+    /**
+     * Creates new {@link UnresolvedEntityTypeException UnresolvedEntityTypeException} with the given message.
+     *
+     * @param message
+     *        - message representing the error that occurred
+     */
+    public UnresolvedEntityTypeException(String message) {
+        super(message);
+    }
+
+    /**
+     * Creates new {@link UnresolvedEntityTypeException UnresolvedEntityTypeException} with the given message and the
+     * {@link Throwable cause} for the exception.
+     *
+     * @param message
+     *        - message representing the error that occurred
+     * @param throwable
+     *        - the cause for the exception
+     */
+    public UnresolvedEntityTypeException(String message, Throwable throwable) {
+        super(message, throwable);
+    }
+}

--- a/src/main/java/com/musala/atmosphere/agent/util/GestureCreator.java
+++ b/src/main/java/com/musala/atmosphere/agent/util/GestureCreator.java
@@ -1,0 +1,210 @@
+package com.musala.atmosphere.agent.util;
+
+import com.musala.atmosphere.commons.beans.SwipeDirection;
+import com.musala.atmosphere.commons.geometry.Point;
+import com.musala.atmosphere.commons.gesture.Anchor;
+import com.musala.atmosphere.commons.gesture.Gesture;
+import com.musala.atmosphere.commons.gesture.Timeline;
+import com.musala.atmosphere.commons.util.Pair;
+
+/**
+ * Serves to create {@link Gesture} later performed by the gesture player.
+ *
+ * @author delyan.dimitrov
+ *
+ */
+public class GestureCreator {
+    private static int DOUBLE_TAP_INTERVAL = 150;
+
+    private static int PINCH_DURATION = 500;
+
+    private static int SWIPE_INTERVAL = 250;
+
+    private static int SWIPE_DISTANCE = 300;
+
+    private static int LONG_PRESS_INTERVAL = 2000;
+
+    private static int DRAG_DURATION = 3000;
+
+    /**
+     * Creates a double tap {@link Gesture} on the passed point.
+     *
+     * @param x
+     *        - the x coordinate of the tap point
+     * @param y
+     *        - the y coordinate of the tap point
+     * @return a {@link Gesture} that represents a double tap on a device
+     */
+    public static Gesture createDoubleTap(float x, float y) {
+        Gesture doubleTap = new Gesture();
+
+        Timeline firstTapTimeline = new Timeline();
+        Anchor firstTap = new Anchor(x, y, 0);
+        firstTapTimeline.add(firstTap);
+        doubleTap.add(firstTapTimeline);
+
+        Timeline secondTapTimeline = new Timeline();
+        Anchor secondTap = new Anchor(x, y, DOUBLE_TAP_INTERVAL);
+        secondTapTimeline.add(secondTap);
+        doubleTap.add(secondTapTimeline);
+
+        return doubleTap;
+    }
+
+    /**
+     * Creates a pinch in {@link Gesture}.
+     *
+     * @param firstFingerInitial
+     *        - the initial position of the first finger performing the gesture
+     * @param secondFingerInitial
+     *        - the initial position of the second finger performing the gesture
+     * @return a {@link Gesture} that represents pinch in on a device.
+     */
+    public static Gesture createPinchIn(Point firstFingerInitial, Point secondFingerInitial) {
+        // calculating the point where the two fingers will meet
+        int toX = (firstFingerInitial.getX() + secondFingerInitial.getX()) / 2;
+        int toY = (firstFingerInitial.getY() + secondFingerInitial.getY()) / 2;
+        Point to = new Point(toX, toY);
+
+        Timeline firstFingerMovement = createScrollMovement(firstFingerInitial, to, PINCH_DURATION);
+        Timeline secondFingerMovement = createScrollMovement(secondFingerInitial, to, PINCH_DURATION);
+
+        Gesture pinchIn = new Gesture();
+        pinchIn.add(firstFingerMovement);
+        pinchIn.add(secondFingerMovement);
+
+        return pinchIn;
+    }
+
+    /**
+     * Creates a pinch out {@link Gesture}.
+     *
+     * @param firstFingerEnd
+     *        - the point where the first finger will be at the end of the pinch
+     * @param secondFingerEnd
+     *        - the point where the second finger will be at the end of the pinch
+     * @return a {@link Gesture} that represents pinch out on a device.
+     */
+    public static Gesture createPinchOut(Point firstFingerEnd, Point secondFingerEnd) {
+        // calculating the start point of the gesture
+        int fromX = (firstFingerEnd.getX() + secondFingerEnd.getX()) / 2;
+        int fromY = (firstFingerEnd.getY() + secondFingerEnd.getY()) / 2;
+        Point from = new Point(fromX, fromY);
+
+        Timeline firstFingerMovement = createScrollMovement(from, firstFingerEnd, PINCH_DURATION);
+        Timeline secondFingerMovement = createScrollMovement(from, secondFingerEnd, PINCH_DURATION);
+
+        Gesture pinchOut = new Gesture();
+        pinchOut.add(firstFingerMovement);
+        pinchOut.add(secondFingerMovement);
+
+        return pinchOut;
+    }
+
+    /**
+     * Creates a swipe gesture {@link Gesture} from passed point in passed direction.
+     *
+     * @param startPoint
+     *        - the start point of the swipe
+     * @param swipeDirection
+     *        - the direction of the swipe
+     * @param resolution
+     *        - this is a pair which present the resolution of the screen
+     * @return a {@link Gesture} that represents swipe on a device.
+     */
+    public static Gesture createSwipe(Point startPoint, SwipeDirection swipeDirection, Pair<Integer, Integer> resolution) {
+        int endX = startPoint.getX();
+        int endY = startPoint.getY();
+
+        switch (swipeDirection) {
+            case UP:
+                endY = Math.max(endY - SWIPE_DISTANCE, 0);
+                break;
+            case DOWN:
+                endY = Math.min(endY + SWIPE_DISTANCE, resolution.getValue());
+                break;
+            case LEFT:
+                endX = Math.max(endX - SWIPE_DISTANCE, 0);
+                break;
+            case RIGHT:
+                endX = Math.min(endX + SWIPE_DISTANCE, resolution.getKey());
+                break;
+        }
+
+        Point endPoint = new Point(endX, endY);
+        Timeline swipeTimeline = createScrollMovement(startPoint, endPoint, SWIPE_INTERVAL);
+
+        Gesture swipe = new Gesture();
+        swipe.add(swipeTimeline);
+
+        return swipe;
+    }
+
+    /**
+     * Defines a {@link Timeline} for a scroll between two points with a given duration.
+     *
+     * @param from
+     *        - the initial point of the motion
+     * @param to
+     *        - the end point of the motion
+     * @param duration
+     *        - the duration of the scroll motion in milliseconds
+     * @return a {@link Timeline} representing a scroll motion on a device.
+     */
+    private static Timeline createScrollMovement(Point from, Point to, int duration) {
+        Timeline scroll = new Timeline();
+
+        Anchor startPoint = new Anchor(from.getX(), from.getY(), 0);
+        scroll.add(startPoint);
+        Anchor endPoint = new Anchor(to.getX(), to.getY(), duration);
+        scroll.add(endPoint);
+
+        return scroll;
+    }
+
+    /**
+     * Defines a {@link Timeline} for a long press gesture. A {@link Timeline} represents a single finger gesture which
+     * contains the {@link Anchor Anchor} points that the current pointer will traverse and represent a long press on a
+     * Device.
+     *
+     * @param x
+     *        - the x coordinate of the tap point;
+     * @param y
+     *        - the y coordinate of the tap point;
+     * @param timeout
+     *        - the time in ms for which the point should stay pressed.
+     * @return a {@link Timeline} representing a long press on a device.
+     */
+    public static Gesture createLongPress(int x, int y, int timeout) {
+
+        Timeline pressTimeline = new Timeline();
+        pressTimeline.add(new Anchor(x, y, 0));
+        pressTimeline.add(new Anchor(x, y, timeout));
+
+        Gesture longPress = new Gesture();
+        longPress.add(pressTimeline);
+        return longPress;
+    }
+
+    /**
+     * Defines a {@link Timeline) for a drag and drop gesture. A {@link Timeline} represents a single finger gesture
+     * which contains the {$link Anchor Anchor} points that the current pointer will traverse and represent drag and
+     * drop on a Device.
+     *
+     * @param startPoint
+     *        - the starting point of the drag and drop gesture
+     * @param endPoint
+     *        - the destination point of the drag and drop gesture
+     * @return a {@link Gesture} representing a drag and drop on a device
+     */
+    public static Gesture createDrag(Point startPoint, Point endPoint) {
+        Timeline dragTimeline = new Timeline();
+        dragTimeline.add(new Anchor(startPoint.getX(), startPoint.getY(), 0));
+        dragTimeline.add(new Anchor(startPoint.getX(), startPoint.getY(), LONG_PRESS_INTERVAL));
+        dragTimeline.add(new Anchor(endPoint.getX(), endPoint.getY(), DRAG_DURATION));
+
+        Gesture dragAndDrop = new Gesture();
+        dragAndDrop.add(dragTimeline);
+        return dragAndDrop;
+    }
+}

--- a/src/main/java/com/musala/atmosphere/agent/util/settings/AndroidGlobalSettings.java
+++ b/src/main/java/com/musala/atmosphere/agent/util/settings/AndroidGlobalSettings.java
@@ -1,0 +1,255 @@
+package com.musala.atmosphere.agent.util.settings;
+
+/**
+ * Global system settings, containing preferences that always apply identically to all defined users. Applications can
+ * read these but are not allowed to write; like the "Secure" settings, these are for preferences that the user must
+ * explicitly modify through the system UI or specialized APIs for those values. We can get or change these settings
+ * using the 'content' command utility provided by Android's shell.
+ *
+ * @see <a href="http://developer.android.com/reference/android/provider/Settings.Global.html">developer.android.com</a>
+ *
+ * @author nikola.taushanov
+ *
+ */
+public enum AndroidGlobalSettings implements IAndroidSettings {
+    /**
+     * Whether Airplane Mode is on.
+     */
+    AIRPLANE_MODE_ON("airplane_mode_on"),
+
+    /**
+     * Constant for use in AIRPLANE_MODE_RADIOS to specify Bluetooth radio.
+     */
+    RADIO_BLUETOOTH("bluetooth"),
+
+    /**
+     * Constant for use in AIRPLANE_MODE_RADIOS to specify Wi-Fi radio.
+     */
+    RADIO_WIFI("wifi"),
+
+    /**
+     * Constant for use in AIRPLANE_MODE_RADIOS to specify Cellular radio.
+     */
+    RADIO_CELL("cell"),
+
+    /**
+     * Constant for use in AIRPLANE_MODE_RADIOS to specify NFC radio.
+     */
+    RADIO_NFC("nfc"),
+
+    /**
+     * A comma separated list of radios that need to be disabled when airplane mode is on. This overrides WIFI_ON and
+     * BLUETOOTH_ON, if Wi-Fi and bluetooth are included in the comma separated list.
+     */
+    AIRPLANE_MODE_RADIOS("airplane_mode_radios"),
+
+    /**
+     * The policy for deciding when Wi-Fi should go to sleep (which will in turn switch to using the mobile data as an
+     * Internet connection).
+     * <p>
+     * Set to one of {@link #WIFI_SLEEP_POLICY_DEFAULT}, {@link #WIFI_SLEEP_POLICY_NEVER_WHILE_PLUGGED}, or
+     * {@link #WIFI_SLEEP_POLICY_NEVER}.
+     */
+    WIFI_SLEEP_POLICY("wifi_sleep_policy"),
+
+    /**
+     * Value to specify if the user prefers the date, time and time zone to be automatically fetched from the network
+     * (NITZ). 1yes, 0no
+     */
+    AUTO_TIME("auto_time"),
+
+    /**
+     * Value to specify if the user prefers the time zone to be automatically fetched from the network (NITZ). 1yes, 0no
+     */
+    AUTO_TIME_ZONE("auto_time_zone"),
+
+    /**
+     * Whether we keep the device on while the device is plugged in. Supported values are:
+     * <ul>
+     * <li>{@code 0} to never stay on while plugged in</li>
+     * <li>{@code 1} to stay on for AC charger</li>
+     * <li>{@code 2} to stay on for USB charger</li>
+     * <li>{@code 4} to stay on for wireless charger</li>
+     * </ul>
+     * These values can be OR-ed together.
+     */
+    STAY_ON_WHILE_PLUGGED_IN("stay_on_while_plugged_in"),
+
+    /**
+     * Whether ADB is enabled.
+     */
+    ADB_ENABLED("adb_enabled"),
+
+    /**
+     * Whether bluetooth is enabled/disabled 0disabled. 1enabled.
+     */
+    BLUETOOTH_ON("bluetooth_on"),
+
+    /**
+     * Whether or not data roaming is enabled. (0 false, 1 true)
+     */
+    DATA_ROAMING("data_roaming"),
+
+    /**
+     * Whether user has enabled development settings.
+     */
+    DEVELOPMENT_SETTINGS_ENABLED("development_settings_enabled"),
+
+    /**
+     * Whether the device has been provisioned (0 false, 1 true)
+     */
+    DEVICE_PROVISIONED("device_provisioned"),
+
+    /**
+     * Whether the package installer should allow installation of apps downloaded from sources other than Google Play.
+     *
+     * 1 allow installing from other sources 0 only allow installing from Google Play
+     */
+    INSTALL_NON_MARKET_APPS("install_non_market_apps"),
+
+    /**
+     * User preference for which network(s) should be used. Only the connectivity service should touch this.
+     */
+    NETWORK_PREFERENCE("network_preference"),
+
+    /**
+     * USB Mass Storage Enabled
+     */
+    USB_MASS_STORAGE_ENABLED("usb_mass_storage_enabled"),
+
+    /**
+     * If this setting is set (to anything), then all references to Gmail on the device must change to Google Mail.
+     */
+    USE_GOOGLE_MAIL("use_google_mail"),
+
+    /**
+     * Whether to notify the user of open networks.
+     * <p>
+     * If not connected and the scan results have an open network, we will put this notification up. If we attempt to
+     * connect to a network or the open network(s) disappear, we remove the notification. When we show the notification,
+     * we will not show it again for {@link android.provider.Settings.Secure#WIFI_NETWORKS_AVAILABLE_REPEAT_DELAY} time.
+     */
+    WIFI_NETWORKS_AVAILABLE_NOTIFICATION_ON("wifi_networks_available_notification_on"),
+
+    /**
+     * Delay (in seconds) before repeating the Wi-Fi networks available notification. Connecting to a network will reset
+     * the timer.
+     */
+    WIFI_NETWORKS_AVAILABLE_REPEAT_DELAY("wifi_networks_available_repeat_delay"),
+
+    /**
+     * When the number of open networks exceeds this number, the least-recently-used excess networks will be removed.
+     */
+    WIFI_NUM_OPEN_NETWORKS_KEPT("wifi_num_open_networks_kept"),
+
+    /**
+     * Whether the Wi-Fi should be on. Only the Wi-Fi service should touch this.
+     */
+    WIFI_ON("wifi_on"),
+
+    /**
+     * Whether the Wi-Fi watchdog is enabled.
+     */
+    WIFI_WATCHDOG_ON("wifi_watchdog_on"),
+
+    /**
+     * The maximum number of times we will retry a connection to an access point for which we have failed in acquiring
+     * an IP address from DHCP. A value of N means that we will make N+1 connection attempts in all.
+     */
+    WIFI_MAX_DHCP_RETRY_COUNT("wifi_max_dhcp_retry_count"),
+
+    /**
+     * Maximum amount of time in milliseconds to hold a wakelock while waiting for mobile data connectivity to be
+     * established after a disconnect from Wi-Fi.
+     */
+    WIFI_MOBILE_DATA_TRANSITION_WAKELOCK_TIMEOUT_MS("wifi_mobile_data_transition_wakelock_timeout_ms"),
+
+    /**
+     * Ringer mode. This is used internally, changing this value will not change the ringer mode. See AudioManager.
+     */
+    MODE_RINGER("mode_ringer"),
+
+    /**
+     * Host name and port for global http proxy. Uses ':' seperator for between host and port.
+     */
+    HTTP_PROXY("http_proxy"),
+
+    /**
+     * Scaling factor for normal window animations. Setting to 0 will disable window animations.
+     */
+    WINDOW_ANIMATION_SCALE("window_animation_scale"),
+
+    /**
+     * Scaling factor for activity transition animations. Setting to 0 will disable window animations.
+     */
+    TRANSITION_ANIMATION_SCALE("transition_animation_scale"),
+
+    /**
+     * Scaling factor for Animator-based animations. This affects both the start delay and duration of all such
+     * animations. Setting to 0 will cause animations to end immediately. The default value is 1.
+     */
+    ANIMATOR_DURATION_SCALE("animator_duration_scale"),
+
+    /**
+     * Name of an application package to be debugged.
+     */
+    DEBUG_APP("debug_app"),
+
+    /**
+     * If 1, when launching DEBUG_APP it will wait for the debugger before starting user code. If 0, it will run
+     * normally.
+     */
+    WAIT_FOR_DEBUGGER("wait_for_debugger"),
+
+    /**
+     * Control whether the process CPU usage meter should be shown.
+     */
+    SHOW_PROCESSES("show_processes"),
+
+    /**
+     * If 1, the activity manager will aggressively finish activities and processes as soon as they are no longer
+     * needed. If 0, the normal extended lifetime is used.
+     */
+    ALWAYS_FINISH_ACTIVITIES("always_finish_activities");
+
+    /**
+     * Value for {@link #WIFI_SLEEP_POLICY} to use the default Wi-Fi sleep policy, which is to sleep shortly after the
+     * turning off according to the {@link #STAY_ON_WHILE_PLUGGED_IN} setting.
+     */
+    public static final int WIFI_SLEEP_POLICY_DEFAULT = 0;
+
+    /**
+     * Value for {@link #WIFI_SLEEP_POLICY} to use the default policy when the device is on battery, and never go to
+     * sleep when the device is plugged in.
+     */
+    public static final int WIFI_SLEEP_POLICY_NEVER_WHILE_PLUGGED = 1;
+
+    /**
+     * Value for {@link #WIFI_SLEEP_POLICY} to never go to sleep.
+     */
+    public static final int WIFI_SLEEP_POLICY_NEVER = 2;
+
+    private static final String CONTENT_URI = "content://settings/global";
+
+    private String settingName;
+
+    AndroidGlobalSettings(String settingName) {
+        this.settingName = settingName;
+    }
+
+    /**
+     * @return the name of the enum constant
+     */
+    @Override
+    public String toString() {
+        return settingName;
+    }
+
+    /**
+     * @return the uniform resource identifier
+     */
+    @Override
+    public String getContentUri() {
+        return CONTENT_URI;
+    }
+}

--- a/src/main/java/com/musala/atmosphere/agent/util/settings/AndroidSecureSettings.java
+++ b/src/main/java/com/musala/atmosphere/agent/util/settings/AndroidSecureSettings.java
@@ -1,0 +1,44 @@
+package com.musala.atmosphere.agent.util.settings;
+
+/**
+ * Secure system settings, containing system preferences that applications can read but are not allowed to write. These
+ * are for preferences that the user must explicitly modify through the system UI or specialized APIs for those values,
+ * not modified directly by applications. We can get or change these settings using the 'content' command utility
+ * provided by Android's shell.
+ *
+ * @see <a href="http://developer.android.com/reference/android/provider/Settings.Secure.html">developer.android.com</a>
+ *
+ * @author nikola.taushanov
+ *
+ */
+public enum AndroidSecureSettings implements IAndroidSettings {
+    // TODO: Implement someday when required.
+    /**
+     * None value.
+     */
+    NONE("");
+
+    private String settingName;
+
+    private static final String CONTENT_URI = "content://settings/secure";
+
+    private AndroidSecureSettings(String settingName) {
+        this.settingName = settingName;
+    }
+
+    /**
+     * @return the name of the enum constant
+     */
+    @Override
+    public String toString() {
+        return settingName;
+    }
+
+    /**
+     * @return the uniform resource identifier
+     */
+    @Override
+    public String getContentUri() {
+        return CONTENT_URI;
+    }
+}

--- a/src/main/java/com/musala/atmosphere/agent/util/settings/AndroidSystemSettings.java
+++ b/src/main/java/com/musala/atmosphere/agent/util/settings/AndroidSystemSettings.java
@@ -1,0 +1,251 @@
+package com.musala.atmosphere.agent.util.settings;
+
+/**
+ * System settings, containing miscellaneous system preferences. We can get or change these settings using the 'content'
+ * command utility provided by Android's shell.
+ *
+ * @see <a href="http://developer.android.com/reference/android/provider/Settings.System.html">developer.android.com</a>
+ *
+ * @author nikola.taushanov
+ *
+ */
+public enum AndroidSystemSettings implements IAndroidSettings {
+    /**
+     * WARNING: Moved to {@link AndroidGlobalSettings} since Android 4.2.2. Whether Airplane Mode is on.
+     */
+    AIRPLANE_MODE_ON("airplane_mode_on"),
+
+    /**
+     * Determines whether remote devices may discover and/or connect to this device.
+     * <P>
+     * Type: INT
+     * </P>
+     * 2 -- discoverable and connectable 1 -- connectable but not discoverable 0 -- neither connectable nor discoverable
+     */
+    BLUETOOTH_DISCOVERABILITY("bluetooth_discoverability"),
+
+    /**
+     * Bluetooth discoverability timeout. If this value is nonzero, then Bluetooth becomes discoverable for a certain
+     * number of seconds, after which is becomes simply connectable. The value is in seconds.
+     */
+    BLUETOOTH_DISCOVERABILITY_TIMEOUT("bluetooth_discoverability_timeout"),
+
+    /**
+     * A formatted string of the next alarm that is set, or the empty string if there is no alarm set.
+     */
+    NEXT_ALARM_FORMATTED("next_alarm_formatted"),
+
+    /**
+     * Scaling factor for fonts, float.
+     */
+    FONT_SCALE("font_scale"),
+
+    /**
+     * The timeout before the screen turns off.
+     */
+    SCREEN_OFF_TIMEOUT("screen_off_timeout"),
+
+    /**
+     * The screen backlight brightness between 0 and 255.
+     */
+    SCREEN_BRIGHTNESS("screen_brightness"),
+
+    /**
+     * Control whether to enable automatic brightness mode.
+     */
+    SCREEN_BRIGHTNESS_MODE("screen_brightness_mode"),
+
+    /**
+     * Determines which streams are affected by ringer mode changes. The stream type's bit should be set to 1 if it
+     * should be muted when going into an inaudible ringer mode.
+     */
+    MODE_RINGER_STREAMS_AFFECTED("mode_ringer_streams_affected"),
+
+    /**
+     * Determines which streams are affected by mute. The stream type's bit should be set to 1 if it should be muted
+     * when a mute request is received.
+     */
+    MUTE_STREAMS_AFFECTED("mute_streams_affected"),
+
+    /**
+     * Whether vibrate is on for different events. This is used internally, changing this value will not change the
+     * vibrate. See AudioManager.
+     */
+    VIBRATE_ON("vibrate_on"),
+
+    /**
+     * Ringer volume. This is used internally, changing this value will not change the volume. See AudioManager.
+     */
+    VOLUME_RING("volume_ring"),
+
+    /**
+     * System/notifications volume. This is used internally, changing this value will not change the volume. See
+     * AudioManager.
+     */
+    VOLUME_SYSTEM("volume_system"),
+
+    /**
+     * Voice call volume. This is used internally, changing this value will not change the volume. See AudioManager.
+     */
+    VOLUME_VOICE("volume_voice"),
+
+    /**
+     * Music/media/gaming volume. This is used internally, changing this value will not change the volume. See
+     * AudioManager.
+     */
+    VOLUME_MUSIC("volume_music"),
+
+    /**
+     * Alarm volume. This is used internally, changing this value will not change the volume. See AudioManager.
+     */
+    VOLUME_ALARM("volume_alarm"),
+
+    /**
+     * Notification volume. This is used internally, changing this value will not change the volume. See AudioManager.
+     */
+    VOLUME_NOTIFICATION("volume_notification"),
+
+    /**
+     * Bluetooth Headset volume. This is used internally, changing this value will not change the volume. See
+     * AudioManager.
+     */
+    VOLUME_BLUETOOTH_SCO("volume_bluetooth_sco"),
+
+    /**
+     * Appended to various volume related settings to record the previous values before they the settings were affected
+     * by a silent/vibrate ringer mode change.
+     */
+    APPEND_FOR_LAST_AUDIBLE("_last_audible"),
+
+    /**
+     * Persistent store for the system-wide default ringtone URI.
+     * <p>
+     * If you need to play the default ringtone at any given time, it is recommended you give
+     * DEFAULT_RINGTONE_URI(checkout the android public api doc for more information) to the media player. It will
+     * resolve to the set default ringtone at the time of playing.
+     */
+    RINGTONE("ringtone"),
+
+    /**
+     * Persistent store for the system-wide default notification sound.
+     *
+     * @see #RINGTONE
+     */
+    NOTIFICATION_SOUND("notification_sound"),
+
+    /**
+     * Persistent store for the system-wide default alarm alert.
+     *
+     * @see #RINGTONE
+     */
+    ALARM_ALERT("alarm_alert"),
+
+    /**
+     * Setting to enable Auto Replace (AutoText) in text editors. 1(On, 0(Off
+     */
+    TEXT_AUTO_REPLACE("auto_replace"),
+
+    /**
+     * Setting to enable Auto Caps in text editors. 1(On, 0(Off
+     */
+    TEXT_AUTO_CAPS("auto_caps"),
+
+    /**
+     * Setting to enable Auto Punctuate in text editors. 1(On, 0(Off. This feature converts two spaces to a "." and
+     * space.
+     */
+    TEXT_AUTO_PUNCTUATE("auto_punctuate"),
+
+    /**
+     * Setting to showing password characters in text editors. 1(On, 0(Off
+     */
+    TEXT_SHOW_PASSWORD("show_password"),
+
+    /**
+     * Setting to showing the current Gtalk service status.
+     */
+    SHOW_GTALK_SERVICE_STATUS("SHOW_GTALK_SERVICE_STATUS"),
+
+    /**
+     * Display times as 12 or 24 hours 12 24
+     */
+    TIME_12_24("time_12_24"),
+
+    /**
+     * Date format string mm/dd/yyyy dd/mm/yyyy yyyy/mm/dd
+     */
+    DATE_FORMAT("date_format"),
+
+    /**
+     * Whether the setup wizard has been run before (on first boot), or if it still needs to be run.
+     *
+     * nonzero(it has been run in the past 0(it has not been run in the past
+     */
+    SETUP_WIZARD_HAS_RUN("setup_wizard_has_run"),
+
+    /**
+     * Control whether the accelerometer will be used to change screen orientation. If 0, it will not be used unless
+     * explicitly requested by the application; if 1, it will be used by default unless explicitly disabled by the
+     * application.
+     */
+    ACCELEROMETER_ROTATION("accelerometer_rotation"),
+
+    /**
+     * Default screen rotation when no other policy applies. When {@link #ACCELEROMETER_ROTATION} is zero and no
+     * on-screen Activity expresses a preference, this rotation value will be used. Must be one of the Surface rotation
+     * constants}.
+     */
+    USER_ROTATION("user_rotation"),
+
+    /**
+     * Whether the audible DTMF tones are played by the dialer when dialing. The value is boolean (1 or 0).
+     */
+    DTMF_TONE_WHEN_DIALING("dtmf_tone"),
+
+    /**
+     * Whether the sounds effects (key clicks, lid open ...) are enabled. The value is boolean (1 or 0).
+     */
+    SOUND_EFFECTS_ENABLED("sound_effects_enabled"),
+
+    /**
+     * Whether the haptic feedback (long presses, ...) are enabled. The value is boolean (1 or 0).
+     */
+    HAPTIC_FEEDBACK_ENABLED("haptic_feedback_enabled"),
+
+    /**
+     * <p>
+     * What happens when the user presses the end call button if they're not on a call.
+     * </p>
+     * <b>Values:</b>
+     * <p>
+     * 0 - The end button does nothing 1 - The end button goes to the home screen. 2 - The end button puts the device to
+     * sleep and locks the keyguard. 3 - The end button goes to the home screen. If the user is already on the home
+     * screen, it puts the device to sleep.
+     * </p>
+     */
+    END_BUTTON_BEHAVIOR("end_button_behavior");
+
+    private static final String CONTENT_URI = "content://settings/system";
+
+    private String settingName;
+
+    AndroidSystemSettings(String settingName) {
+        this.settingName = settingName;
+    }
+
+    /**
+     * @return the name of the enum constant
+     */
+    @Override
+    public String toString() {
+        return settingName;
+    }
+
+    /**
+     * @return the uniform resource identifier
+     */
+    @Override
+    public String getContentUri() {
+        return CONTENT_URI;
+    }
+}

--- a/src/main/java/com/musala/atmosphere/agent/util/settings/DeviceSettingsManager.java
+++ b/src/main/java/com/musala/atmosphere/agent/util/settings/DeviceSettingsManager.java
@@ -1,0 +1,261 @@
+package com.musala.atmosphere.agent.util.settings;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import com.musala.atmosphere.agent.devicewrapper.util.ShellCommandExecutor;
+import com.musala.atmosphere.commons.exceptions.CommandFailedException;
+
+/**
+ * Provides better interface for getting and inserting all kinds of Android device settings.
+ *
+ * @author nikola.taushanov
+ *
+ */
+public class DeviceSettingsManager {
+    private ShellCommandExecutor shellCommandExecutor;
+
+    public DeviceSettingsManager(ShellCommandExecutor shellCommandExecutor) {
+        this.shellCommandExecutor = shellCommandExecutor;
+    }
+
+    /**
+     * Retrieves a single setting value as floating point number or returns default value if it is not found.
+     *
+     * @param setting
+     *        - android setting.
+     * @param defaultValue
+     *        - default value which should be returned if the retrieving fails.
+     * @return Floating point number if the retrieving succeed, defaultValue if it fails.
+     */
+
+    public float getFloat(IAndroidSettings setting, float defaultValue) {
+        try {
+            float result = getFloat(setting);
+            return result;
+        } catch (SettingsParsingException e) {
+            return defaultValue;
+        }
+    }
+
+    /**
+     * Retrieves a single setting value as floating point number.
+     *
+     * @param setting
+     *        - android setting..
+     * @return Floating point number if the retrieving succeed.
+     * @throws SettingsParsingException
+     *         - Retrieving the single setting value as floating point number failed.
+     */
+    public float getFloat(IAndroidSettings setting) throws SettingsParsingException {
+        String settingStringValue = getSetting(setting);
+        try {
+            float settingValue = Float.parseFloat(settingStringValue);
+            return settingValue;
+        } catch (NumberFormatException e) {
+            throw new SettingsParsingException(e.getMessage());
+        }
+    }
+
+    /**
+     * Retrieves a single setting value as integer or returns default value if it is not found.
+     *
+     * @param setting
+     *        - android setting.
+     * @param defaultValue
+     *        - default value which should be returned if the retrieving fails.
+     * @return The single setting value as integer if retrieving succeed, defaultValue if it fails.
+     */
+    public int getInt(IAndroidSettings setting, int defaultValue) {
+        try {
+            int result = getInt(setting);
+            return result;
+        } catch (SettingsParsingException e) {
+            return defaultValue;
+        }
+    }
+
+    /**
+     * Retrieves a single setting value as integer.
+     *
+     * @param setting
+     *        - android setting.
+     * @return The single setting value as integer if the retrieving succeed.
+     * @throws SettingsParsingException
+     *         - Retrieving the single setting value as integer failed.
+     */
+    public int getInt(IAndroidSettings setting) throws SettingsParsingException {
+        String settingStringValue = getSetting(setting);
+        try {
+            int settingValue = Integer.parseInt(settingStringValue);
+            return settingValue;
+        } catch (NumberFormatException e) {
+            throw new SettingsParsingException(e.getMessage());
+        }
+    }
+
+    /**
+     * Retrieves a single setting value as long or returns default value if it is not found.
+     *
+     * @param setting
+     *        - android setting.
+     * @param defaultValue
+     *        - default value which should be returned if the retrieving fails.
+     * @return The single setting value as long if retrieving succeed, defaultValue if it fails.
+     */
+    public long getLong(IAndroidSettings setting, long defaultValue) {
+        try {
+            long result = getLong(setting);
+            return result;
+        } catch (SettingsParsingException e) {
+            return defaultValue;
+        }
+    }
+
+    /**
+     * Retrieves a single setting value as long.
+     *
+     * @param setting
+     *        - android setting.
+     * @return The single setting value as long if the retrieving succeed.
+     * @throws SettingsParsingException
+     *         - Retrieving the single setting value as long failed.
+     */
+    public long getLong(IAndroidSettings setting) throws SettingsParsingException {
+        String settingStringValue = getSetting(setting);
+        try {
+            long settingValue = Long.parseLong(settingStringValue);
+            return settingValue;
+        } catch (NumberFormatException e) {
+            throw new SettingsParsingException(e.getMessage());
+        }
+    }
+
+    /**
+     * Retrieves a single setting value as String or returns default value if it is not found.
+     *
+     * @param setting
+     *        - android setting.
+     * @param defaultValue
+     *        - default value which should be returned if the retrieving fails.
+     * @return The string value of the setting or defaultValue if the fetching was not successful.
+     */
+    public String getString(IAndroidSettings setting, String defaultValue) {
+        String settingValue = getSetting(setting);
+
+        if (settingValue != null) {
+            return settingValue;
+        } else {
+            return defaultValue;
+        }
+    }
+
+    /**
+     * Retrieves a single setting value as String.
+     *
+     * @param setting
+     *        - android setting.
+     * @return The string value of the setting or <code>null</code> if the fetching was not successful.
+     */
+    public String getString(IAndroidSettings setting) {
+        String settingValue = getSetting(setting);
+        return settingValue;
+    }
+
+    /**
+     * Updates a single settings value as a floating point number.
+     *
+     * @param setting
+     *        - android setting.
+     * @param value
+     *        - value to be set.
+     * @return boolean indicating whether the updating was successful.
+     */
+    public boolean putFloat(IAndroidSettings setting, float value) {
+        return putSetting(setting, "f", Float.toString(value));
+    }
+
+    /**
+     * Updates a single settings value as integer.
+     *
+     * @param setting
+     *        - android setting.
+     * @param value
+     *        - value to be set.
+     * @return boolean indicating whether the updating was successful.
+     */
+    public boolean putInt(IAndroidSettings setting, int value) {
+        return putSetting(setting, "i", Integer.toString(value));
+    }
+
+    /**
+     * Updates a single settings value as long.
+     *
+     * @param setting
+     *        - android setting.
+     * @param value
+     *        - value to be set.
+     * @return boolean indicating whether the updating was successful.
+     */
+    public boolean putLong(IAndroidSettings setting, long value) {
+        return putSetting(setting, "l", Long.toString(value));
+    }
+
+    /**
+     * Updates a single settings value as String.
+     *
+     * @param setting
+     *        - android setting.
+     * @param value
+     *        - value to be set.
+     * @return boolean indicating whether the updating was successful.
+     */
+    public boolean putString(IAndroidSettings setting, String value) {
+        return putSetting(setting, "s", value);
+    }
+
+    private String getSetting(IAndroidSettings setting) {
+        StringBuilder contentShellCommand = new StringBuilder();
+        contentShellCommand.append("content query --uri " + setting.getContentUri());
+        contentShellCommand.append(" --projection value");
+        contentShellCommand.append(" --where \"name=\'" + setting + "\'\"");
+
+        String shellCommandResult = "";
+
+        try {
+            shellCommandResult = shellCommandExecutor.execute(contentShellCommand.toString());
+        } catch (CommandFailedException e) {
+            return null;
+        }
+
+        Pattern returnValuePattern = Pattern.compile("value=(.*)$");
+        Matcher returnValueMatcher = returnValuePattern.matcher(shellCommandResult);
+
+        if (returnValueMatcher.find()) {
+            return returnValueMatcher.group(1);
+        } else {
+            return null;
+        }
+    }
+
+    private boolean putSetting(IAndroidSettings setting, String valueType, String value) {
+        StringBuilder contentShellCommand = new StringBuilder();
+        contentShellCommand.append("content insert --uri " + setting.getContentUri());
+        contentShellCommand.append(" --bind name:s:" + setting);
+        contentShellCommand.append(" --bind value:" + valueType + ":" + value);
+
+        return executeShellCommand(contentShellCommand.toString());
+    }
+
+    private boolean executeShellCommand(String shellCommand) {
+        boolean isCommandExecutionSuccessful = true;
+
+        try {
+            shellCommandExecutor.execute(shellCommand);
+        } catch (CommandFailedException e) {
+            isCommandExecutionSuccessful = false;
+        }
+
+        return isCommandExecutionSuccessful;
+    }
+}

--- a/src/main/java/com/musala/atmosphere/agent/util/settings/IAndroidSettings.java
+++ b/src/main/java/com/musala/atmosphere/agent/util/settings/IAndroidSettings.java
@@ -1,0 +1,14 @@
+package com.musala.atmosphere.agent.util.settings;
+
+/**
+ * General interface class for all classes which work with Android settings.
+ *
+ * @author yavor.stankov
+ *
+ */
+public interface IAndroidSettings {
+    /**
+     * @return the uniform resource identifier
+     */
+    public String getContentUri();
+}

--- a/src/main/java/com/musala/atmosphere/agent/util/settings/SettingsParsingException.java
+++ b/src/main/java/com/musala/atmosphere/agent/util/settings/SettingsParsingException.java
@@ -1,0 +1,19 @@
+package com.musala.atmosphere.agent.util.settings;
+
+/**
+ * Thrown when the parsing of the settings is not successful.
+ *
+ * @author nikola.taushanov
+ *
+ */
+public class SettingsParsingException extends Exception {
+    private static final long serialVersionUID = -7142031090292495482L;
+
+    public SettingsParsingException(String message) {
+        super(message);
+    }
+
+    public SettingsParsingException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/src/main/java/com/musala/atmosphere/agent/websocket/AgentDispatcher.java
+++ b/src/main/java/com/musala/atmosphere/agent/websocket/AgentDispatcher.java
@@ -156,14 +156,14 @@ public class AgentDispatcher {
                         try {
                             deviceWrapper.route(requestAction, arguments);
                         } catch (CommandFailedException e) {
-                            sendErrorResponseMessage(e, session, request.getSessionId());
+                            sendErrorResponseMessage(e, session, request);
                             LOGGER.error(ACTION_FAILD_MESSAGE, e);
                         }
                     }
                 }) {}.start();
             }
-        } catch (CommandFailedException e) {
-            sendErrorResponseMessage(e, session, request.getSessionId());
+        } catch (CommandFailedException | IllegalArgumentException e) {
+            sendErrorResponseMessage(e, session, request);
             LOGGER.error(ACTION_FAILD_MESSAGE, e);
         }
     }
@@ -217,9 +217,10 @@ public class AgentDispatcher {
         this.deviceManager = deviceManager;
     }
 
-    private void sendErrorResponseMessage(Exception ex, Session session, String requestSessionId) {
+    private void sendErrorResponseMessage(Exception ex, Session session, RequestMessage request) {
         ResponseMessage errorResponse = new ResponseMessage(MessageAction.ERROR, null, null);
-        errorResponse.setSessionId(requestSessionId);
+        errorResponse.setSessionId(request.getSessionId());
+        errorResponse.setDeviceId(request.getDeviceId());
         errorResponse.setException(ex);
 
         sendText(jsonUtil.serialize(errorResponse), session);

--- a/src/test/java/com/musala/atmosphere/agent/entity/EntityTypeResolverTest.java
+++ b/src/test/java/com/musala/atmosphere/agent/entity/EntityTypeResolverTest.java
@@ -1,0 +1,40 @@
+package com.musala.atmosphere.agent.entity;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+
+import com.musala.atmosphere.commons.DeviceInformation;
+
+/**
+ * Tests {@link EntityTypeResolver}.
+ *
+ * @author filareta.yordanova
+ *
+ */
+// TODO: Add more cases when complex criteria are available, e.g more fields are added to @Restriction.
+public class EntityTypeResolverTest {
+    private static final String ERROR_MESSAGE = "Returned entity instance is not from expected type.";
+
+    private EntityTypeResolver entityFactory;
+
+    @Test
+    public void testGetGpsLocationEntityForApiLevel() {
+        DeviceInformation requiredInformation = new DeviceInformation();
+        requiredInformation.setApiLevel(17);
+        entityFactory = new EntityTypeResolver(requiredInformation);
+
+        Class<?> entityClass = entityFactory.getEntityClass(GpsLocationEntity.class);
+        assertEquals(ERROR_MESSAGE, entityClass, GpsLocationCheckBoxEntity.class);
+    }
+
+    @Test
+    public void testGetGpsLocationEntityWhenNoMatchFound() {
+        DeviceInformation requiredInformation = new DeviceInformation();
+        requiredInformation.setApiLevel(21);
+        entityFactory = new EntityTypeResolver(requiredInformation);
+
+        Class<?> entityClass = entityFactory.getEntityClass(GpsLocationEntity.class);
+        assertEquals(ERROR_MESSAGE, entityClass, GpsLocationSwitchViewEntity.class);
+    }
+}


### PR DESCRIPTION
Move the device-related logic from the client to the agent. This way, when a feature for a specific device is added, it is easier to update just the agents instead of all clients.

This pull request should be merged after MusalaSoft/atmosphere-commons#4 is merged

closes MusalaSoft/atmosphere-docs#93
closes MusalaSoft/atmosphere-docs#95
closes MusalaSoft/atmosphere-docs#96
closes MusalaSoft/atmosphere-docs#98
