### PR TITLE
Update the methods that depend on libraries methods that are deprecated

### DIFF
--- a/src/main/java/com/musala/atmosphere/agent/devicewrapper/util/PreconditionsManager.java
+++ b/src/main/java/com/musala/atmosphere/agent/devicewrapper/util/PreconditionsManager.java
@@ -53,11 +53,6 @@ public class PreconditionsManager {
     private static final int BOOT_ANIMATION_REVALIDATION_SLEEP_TIME = 1000;
 
     /**
-     * The timeout for command execution from the config file.
-     */
-    private static final int COMMAND_EXECUTION_TIMEOUT = AgentPropertiesLoader.getCommandExecutionTimeout();
-
-    /**
      * The path to the on-device components' files from the config file.
      */
     private static final String ON_DEVICE_COMPONENT_FILES_PATH = AgentPropertiesLoader.getOnDeviceComponentFilesPath();

--- a/src/main/java/com/musala/atmosphere/agent/devicewrapper/util/ShellCommandExecutor.java
+++ b/src/main/java/com/musala/atmosphere/agent/devicewrapper/util/ShellCommandExecutor.java
@@ -19,6 +19,7 @@ package com.musala.atmosphere.agent.devicewrapper.util;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.TimeUnit;
 
 import com.android.ddmlib.AdbCommandRejectedException;
 import com.android.ddmlib.CollectingOutputReceiver;
@@ -35,6 +36,9 @@ import com.musala.atmosphere.commons.exceptions.CommandFailedException;
  *
  */
 public class ShellCommandExecutor {
+    /**
+     * The timeout for command execution from the config file.
+     */
     private static final int COMMAND_EXECUTION_TIMEOUT = AgentPropertiesLoader.getCommandExecutionTimeout();
 
     protected final IDevice device;
@@ -68,7 +72,7 @@ public class ShellCommandExecutor {
 
         try {
             CollectingOutputReceiver outputReceiver = new CollectingOutputReceiver();
-            device.executeShellCommand(command, outputReceiver, commandExecutionTimeout);
+            device.executeShellCommand(command, outputReceiver, commandExecutionTimeout, TimeUnit.MILLISECONDS);
 
             response = outputReceiver.getOutput();
         } catch (TimeoutException | AdbCommandRejectedException | ShellCommandUnresponsiveException | IOException e) {

--- a/src/main/java/com/musala/atmosphere/agent/entity/ImeEntity.java
+++ b/src/main/java/com/musala/atmosphere/agent/entity/ImeEntity.java
@@ -20,11 +20,8 @@ import org.apache.log4j.Logger;
 
 import com.musala.atmosphere.agent.devicewrapper.util.ondevicecomponent.ServiceCommunicator;
 import com.musala.atmosphere.commons.exceptions.CommandFailedException;
-import com.musala.atmosphere.commons.geometry.Point;
 import com.musala.atmosphere.commons.ime.KeyboardAction;
 import com.musala.atmosphere.commons.util.AtmosphereIntent;
-
-import android.bluetooth.BluetoothClass.Device;
 
 /**
  * Entity responsible for operations related with the input method engine.

--- a/src/test/java/com/musala/atmosphere/agent/commandline/AgentArgumentParserTest.java
+++ b/src/test/java/com/musala/atmosphere/agent/commandline/AgentArgumentParserTest.java
@@ -30,6 +30,7 @@ import com.musala.atmosphere.commons.exceptions.ArgumentParseException;
  * @author yordan.petrov
  * 
  */
+@SuppressWarnings("unused")
 public class AgentArgumentParserTest {
     private AgentArgumentParser argumentParser = new AgentArgumentParser();
 

--- a/src/test/java/com/musala/atmosphere/agent/commandline/AgentCommandLineTest.java
+++ b/src/test/java/com/musala/atmosphere/agent/commandline/AgentCommandLineTest.java
@@ -135,6 +135,16 @@ public class AgentCommandLineTest {
         assertEquals("Parsed port did not match expected value.", expectedParsedPort, commandLine.getPort());
     }
 
+    @Test
+    public void testParseValidLongArguments() throws Exception {
+        commandLine.parseArguments(validLongArguments);
+
+        assertEquals("Parsed host name did not match expected value.",
+                     expectedParsedHostname,
+                     commandLine.getHostname());
+        assertEquals("Parsed port did not match expected value.", expectedParsedPort, commandLine.getPort());
+    }
+
     @Test(expected = ArgumentParseException.class)
     public void testGetHostnameFromInvalidOptionArgumentsThrowsException() throws Exception {
         commandLine.parseArguments(invalidOptionArguments);

--- a/src/test/java/com/musala/atmosphere/agent/devicewrapper/commandexecutor/ShellCommandExecutorTest.java
+++ b/src/test/java/com/musala/atmosphere/agent/devicewrapper/commandexecutor/ShellCommandExecutorTest.java
@@ -29,7 +29,6 @@ import org.junit.Test;
 
 import com.android.ddmlib.AdbCommandRejectedException;
 import com.android.ddmlib.Client;
-import com.android.ddmlib.CollectingOutputReceiver;
 import com.android.ddmlib.FileListingService;
 import com.android.ddmlib.IDevice;
 import com.android.ddmlib.IShellOutputReceiver;
@@ -58,8 +57,6 @@ public class ShellCommandExecutorTest {
     private ShellCommandExecutor shellCommandExecutor;
 
     private IDevice device;
-
-    private CollectingOutputReceiver outputReceiver;
 
     private class MockedDevice implements IDevice {
         private int expectedCommandExecutionTimeout;


### PR DESCRIPTION
- update the deprecated methods
- remove the unused fields and imports
- fix the unit tests

closes MusalaSoft/atmosphere-docs#164